### PR TITLE
added simplejson to installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     author="@plamere",
     author_email="paul@echonest.com",
     url='http://github.com/plamere/spotipy',
-    install_requires=['requests>=1.0', ],
+    install_requires=['requests>=1.0', 'simplejson>=3.5.2'],
     license='LICENSE.txt',
     py_modules=['spotipy', 'spotipy.oauth2'],)

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -6,6 +6,7 @@ import base64
 import requests
 import simplejson as json
 
+
 __all__ = ['oauth2']
 
 ''' A simple and thin Python library for the Spotify Web API


### PR DESCRIPTION
I've added `simplejson` to the installation requirements to prevent import errors for those using this library without `simplejson` already installed.
