### PR TITLE
Update __init__.py

### DIFF
--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -206,7 +206,7 @@ class Spotify(object):
     def user_playlist(self, user, playlist_id, fields=None):
         ''' Gets playlist of a user
         '''
-        if playlist_id == 'None':
+        if playlist_id == None:
             return self.get("users/%s/starred" % (user), fields=fields)
         return self.get("users/%s/playlists/%s" % (user, playlist_id), fields=fields)
 


### PR DESCRIPTION
user_playlist() didn't work with starred playlists, which are assigned an ID of 'None'. 

Starred playlists use the URI 'users/%s/starred' instead of 'users/%s/playlists/%s'. Adding this fix to support the retrieval of starred playlists.
