### PR TITLE
Rename scope to playlist-modify-public

### DIFF
--- a/examples/add_tracks_to_playlist.py
+++ b/examples/add_tracks_to_playlist.py
@@ -16,7 +16,7 @@ else:
     print "Usage: %s username playlist_id track_id ..." % (sys.argv[0],)
     sys.exit()
 
-scope = 'playlist-modify'
+scope = 'playlist-modify-public'
 token = util.prompt_for_user_token(username, scope)
 
 if token:


### PR DESCRIPTION
Spotify's Web API has renamed the `playlist-modify` scope to `playlist-modify-public` to better describe what it allows. Even though the old one will be supported for some time, the new one is the preferred way to go.
