### PR TITLE
Python 3 compat and per-request oauth state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests==2.3.0
+requests>=2.3.0
+six>=1.8.0

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,2 +1,2 @@
 VERSION='2.0.1'
-from client import Spotify, SpotifyException
+from spotipy.client import Spotify, SpotifyException

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -58,8 +58,8 @@ class SpotifyOAuth(object):
                 if 'scope' not in token_info or self.scope != token_info['scope']:
                     return None
 
-                if self._is_token_expired(token_info):
-                    token_info = self._refresh_access_token(token_info['refresh_token'])
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(token_info['refresh_token'])
 
             except IOError:
                 pass
@@ -76,7 +76,7 @@ class SpotifyOAuth(object):
                 pass
 
 
-    def _is_token_expired(self, token_info):
+    def is_token_expired(self, token_info):
         now = int(time.time())
         return token_info['expires_at'] < now
         
@@ -142,7 +142,7 @@ class SpotifyOAuth(object):
         else:
             return None
 
-    def _refresh_access_token(self, refresh_token):
+    def refresh_access_token(self, refresh_token):
         payload = { 'refresh_token': refresh_token,
                    'grant_type': 'refresh_token'}
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -97,8 +97,6 @@ class SpotifyOAuth(object):
 
         urlparams = urlencode(payload)
 
-        log.info("authorize url params: %r" % urlparams)
-
         return "%s?%s" % (self.OAUTH_AUTHORIZE_URL, urlparams)
 
     def parse_response_code(self, url):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -1,11 +1,13 @@
 from __future__ import print_function
+
 import base64
-import urllib
-import requests
-import os
 import json
 import time
 import sys
+
+import requests
+from six.moves.urllib.parse import urlencode
+
 
 class SpotifyOauthError(Exception):
     pass
@@ -19,7 +21,8 @@ class SpotifyOAuth(object):
     OAUTH_TOKEN_URL = 'https://accounts.spotify.com/api/token'
 
     def __init__(self, client_id, client_secret, redirect_uri, 
-            state=None, scope=None, cache_path=None):
+            state=None, scope=None, cache_path=None,
+            show_dialog=None):
         '''
             Creates a SpotifyOAuth object
 
@@ -38,7 +41,8 @@ class SpotifyOAuth(object):
         self.state=state
         self.cache_path = cache_path
         self.scope=self._normalize_scope(scope)
-   
+        self.show_dialog = show_dialog
+
     def get_cached_token(self):
         ''' Gets a cached auth token
         '''
@@ -76,18 +80,24 @@ class SpotifyOAuth(object):
         now = int(time.time())
         return token_info['expires_at'] < now
         
-    def get_authorize_url(self):
+    def get_authorize_url(self, state=None):
         """ Gets the URL to use to authorize this app
         """
         payload = {'client_id': self.client_id,
                    'response_type': 'code',
                    'redirect_uri': self.redirect_uri}
-        if self.scope:
+        if self.scope is not None:
             payload['scope'] = self.scope
-        if self.state:
-            payload['state'] = self.state
+        if state is None:
+            state = self.state
+        if state is not None:
+            payload['state'] = state
+        if self.show_dialog is not None:
+            payload['show_dialog'] = str(self.show_dialog).lower()
 
-        urlparams = urllib.urlencode(payload)
+        urlparams = urlencode(payload)
+
+        log.info("authorize url params: %r" % urlparams)
 
         return "%s?%s" % (self.OAUTH_AUTHORIZE_URL, urlparams)
 
@@ -110,22 +120,17 @@ class SpotifyOAuth(object):
                 - code - the response code
         """
 
-        payload = {'redirect_uri': self.redirect_uri,
-                   'code': code,
-                   'grant_type': 'authorization_code'}
-        if self.scope:
-            payload['scope'] = self.scope
-        if self.state:
-            payload['state'] = self.state
+        payload = {
+            'redirect_uri': self.redirect_uri,
+            'code': code,
+            'grant_type': 'authorization_code',
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+        }
 
-        auth_header = base64.b64encode(self.client_id + ':' + self.client_secret)
-        headers = {'Authorization': 'Basic %s' % auth_header}
-
-
-        response = requests.post(self.OAUTH_TOKEN_URL, data=payload, 
-            headers=headers, verify=True)
+        response = requests.post(self.OAUTH_TOKEN_URL, data=payload, verify=True)
         if response.status_code is not 200:
-            raise SpotifyOauthError(response.reason)
+            raise SpotifyOauthError(response.reason + '\n' + response.text)
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
         self._save_token_info(token_info)


### PR DESCRIPTION
Fixes for python 3:
- Absolute imports in spotipy.**init**
- use six to find urlencode
- pass client_id/client_secret in post body instead of header during get_access_token.
  A bit of a cop-out I don't really understand why it wasn't working as a header.
  There was something strange happening with the unicode encoding I thought I fixed that
  but then I just kept getting invalid client errors back from spotify. Putting it in the body worked
  first time though

I've kind of mixed in with this making state a parameter of get_authorize_url and removing state and scope
  from get_access_token - I feel bad this should really be another commit.
  These parameters aren't required get_access_token according to the spotify docs and what do you know it works
  with out.
  I also think that it's quite useful if it's convenient to specify the state in the get_authorize_url function
  this is mostly because I'm using that to stash a next page url.
