### PR TITLE
Add 'market' parameter to the search endpoint

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -288,7 +288,7 @@ class Spotify(object):
         tlist = [self._get_id('album', a) for a in albums]
         return self._get('albums/?ids=' + ','.join(tlist))
 
-    def search(self, q, limit=10, offset=0, type='track'):
+    def search(self, q, limit=10, offset=0, type='track', market=None):
         ''' searches for an item
 
             Parameters:
@@ -297,8 +297,9 @@ class Spotify(object):
                 - offset - the index of the first item to return
                 - type - the type of item to return. One of 'artist', 'album',
                          'track' or 'playlist'
+                - market - An ISO 3166-1 alpha-2 country code or the string from_token.
         '''
-        return self._get('search', q=q, limit=limit, offset=offset, type=type)
+        return self._get('search', q=q, limit=limit, offset=offset, type=type, market=market)
 
     def user(self, user):
         ''' Gets basic profile information about a Spotify User


### PR DESCRIPTION
Fixes #57.

Added the missing `market` parameter to the `search` endpoint as described in the [Search for an Item](https://developer.spotify.com/web-api/search-item/) documentation.
