### PR TITLE
make version match history

### DIFF
--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,2 +1,2 @@
-VERSION='2.0.1'
+VERSION='2.3.7'
 from .client import Spotify, SpotifyException


### PR DESCRIPTION
version history says we're at 2.3.7; `VERSION` told a different story; make them match.
