### PR TITLE
Added user_playlist_unfollow() method

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -157,7 +157,6 @@ class Spotify(object):
                 else:
                     raise
 
-
     def _post(self, url, args=None, payload=None, **kwargs):
         if args:
             kwargs.update(args)
@@ -377,6 +376,16 @@ class Spotify(object):
         '''
         data = {'name':name, 'public':public }
         return self._post("users/%s/playlists" % (user,), payload = data)
+
+    def user_playlist_unfollow(self, user, playlist_id):
+        ''' Unfollows (deletes) a playlist for a user
+
+            Parameters:
+                - user - the id of the user
+                - name - the name of the playlist
+                - public - is the created playlist public
+        '''
+        return self._delete("users/%s/playlists/%s/followers" % (user, playlist_id))
 
     def user_playlist_add_tracks(self, user, playlist_id, tracks,
                 position=None):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -383,7 +383,6 @@ class Spotify(object):
             Parameters:
                 - user - the id of the user
                 - name - the name of the playlist
-                - public - is the created playlist public
         '''
         return self._delete("users/%s/playlists/%s/followers" % (user, playlist_id))
 


### PR DESCRIPTION
I've used this API wrapper extensively for the last few months, keep up the good work! I needed the [unfollow a playlist](https://developer.spotify.com/web-api/unfollow-playlist/) endpoint for a project, noticed there wasn't one already written so I added my own. 

I also noticed there was a PR by another user for the same method back in December 2015, but I figure it's a bit easier to use this one since I made the changes on top of the latest version of the master repo. Cheers!