### PR TITLE
Support endpoint for modifying playlist details

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -302,6 +302,7 @@ Spotipy authored by Paul Lamere (plamere) with contributions by:
   - Steve Winton // swinton
   - Tim Balzer // timbalzer 
   - corycorycory // corycorycory 
+  - Nathan Coleman // nathancoleman
 
 License
 =======

--- a/examples/change_playlist_details.py
+++ b/examples/change_playlist_details.py
@@ -1,0 +1,38 @@
+
+# Modify the details of a playlist (name, public, collaborative)
+
+import sys
+
+import spotipy
+import spotipy.util as util
+
+if len(sys.argv) > 3:
+    username = sys.argv[1]
+    playlist_id = sys.argv[2]
+    name = sys.argv[3]
+
+    public = None
+    if len(sys.argv) > 4:
+        public = sys.argv[4].lower() == 'true'
+
+    collaborative = None
+    if len(sys.argv) > 5:
+        collaborative = sys.argv[5].lower() == 'true'
+
+else:
+    print ("Usage: %s username playlist_id name [public collaborative]" %
+           (sys.argv[0]))
+    sys.exit()
+
+scope = 'playlist-modify-public playlist-modify-private'
+token = util.prompt_for_user_token(username, scope)
+
+if token:
+    sp = spotipy.Spotify(auth=token)
+    sp.trace = False
+    results = sp.user_playlist_change_details(
+        username, playlist_id, name=name, public=public,
+        collaborative=collaborative)
+    print results
+else:
+    print "Can't get token for", username

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -378,6 +378,24 @@ class Spotify(object):
         data = {'name':name, 'public':public }
         return self._post("users/%s/playlists" % (user,), payload = data)
 
+    def user_playlist_change_details(
+            self, user, playlist_id, name=None, public=None):
+        ''' Changes a playlist's name and/or public/private state
+
+            Parameters:
+                - user - the id of the user
+                - playlist_id - the id of the playlist
+                - name - optional name of the playlist
+                - public - optional is the playlist public
+        '''
+        data = {}
+        if name is not None:
+            data['name'] = name
+        if public is not None:
+            data['public'] = public
+        return self._put("users/%s/playlists/%s" % (user, playlist_id),
+                         payload=data)
+
     def user_playlist_add_tracks(self, user, playlist_id, tracks,
                 position=None):
         ''' Adds tracks to a playlist

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -383,7 +383,8 @@ class Spotify(object):
         return self._post("users/%s/playlists" % (user,), payload=data)
 
     def user_playlist_change_details(
-            self, user, playlist_id, name=None, public=None):
+            self, user, playlist_id, name=None, public=None,
+            collaborative=None):
         ''' Changes a playlist's name and/or public/private state
 
             Parameters:
@@ -391,12 +392,15 @@ class Spotify(object):
                 - playlist_id - the id of the playlist
                 - name - optional name of the playlist
                 - public - optional is the playlist public
+                - collaborative - optional is the playlist collaborative
         '''
         data = {}
         if name is not None:
             data['name'] = name
-        if public is not None:
+        if isinstance(public, bool):
             data['public'] = public
+        if isinstance(collaborative, bool):
+            data['collaborative'] = collaborative
         return self._put("users/%s/playlists/%s" % (user, playlist_id),
                          payload=data)
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -395,7 +395,7 @@ class Spotify(object):
                 - collaborative - optional is the playlist collaborative
         '''
         data = {}
-        if name is not None:
+        if isinstance(name, basestring):
             data['name'] = name
         if isinstance(public, bool):
             data['public'] = public

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -3,13 +3,13 @@
 
 from __future__ import print_function
 import sys
-import base64
 import requests
 import json
 import time
 
 ''' A simple and thin Python library for the Spotify Web API
 '''
+
 
 class SpotifyException(Exception):
     def __init__(self, http_status, code, msg):
@@ -20,6 +20,7 @@ class SpotifyException(Exception):
     def __str__(self):
         return 'http status: {0}, code:{1} - {2}'.format(
             self.http_status, self.code, self.msg)
+
 
 class Spotify(object):
     '''
@@ -45,7 +46,7 @@ class Spotify(object):
     max_get_retries = 10
 
     def __init__(self, auth=None, requests_session=True,
-        client_credentials_manager=None):
+                 client_credentials_manager=None):
         '''
         Create a Spotify API object.
 
@@ -107,11 +108,12 @@ class Spotify(object):
             r.raise_for_status()
         except:
             if r.text and len(r.text) > 0 and r.text != 'null':
-                raise SpotifyException(r.status_code,
-                    -1, '%s:\n %s' % (r.url, r.json()['error']['message']))
+                raise SpotifyException(
+                    r.status_code, -1,
+                    '%s:\n %s' % (r.url, r.json()['error']['message']))
             else:
-                raise SpotifyException(r.status_code,
-                    -1, '%s:\n %s' % (r.url, 'error'))
+                raise SpotifyException(
+                    r.status_code, -1, '%s:\n %s' % (r.url, 'error'))
         finally:
             r.connection.close()
         if r.text and len(r.text) > 0 and r.text != 'null':
@@ -144,7 +146,7 @@ class Spotify(object):
                         delay += 1
                 else:
                     raise
-            except Exception as e: 
+            except Exception as e:
                 raise
                 print ('exception', str(e))
                 # some other exception. Requests have
@@ -156,7 +158,6 @@ class Spotify(object):
                     delay += 1
                 else:
                     raise
-
 
     def _post(self, url, args=None, payload=None, **kwargs):
         if args:
@@ -228,7 +229,6 @@ class Spotify(object):
         trid = self._get_id('artist', artist_id)
         return self._get('artists/' + trid)
 
-
     def artists(self, artists):
         ''' returns a list of artists given the artist IDs, URIs, or URLs
 
@@ -239,8 +239,8 @@ class Spotify(object):
         tlist = [self._get_id('artist', a) for a in artists]
         return self._get('artists/?ids=' + ','.join(tlist))
 
-    def artist_albums(self, artist_id, album_type=None, country=None,
-            limit=20, offset=0):
+    def artist_albums(self, artist_id, album_type=None, country=None, limit=20,
+                      offset=0):
         ''' Get Spotify catalog information about an artist's albums
 
             Parameters:
@@ -253,7 +253,7 @@ class Spotify(object):
 
         trid = self._get_id('artist', artist_id)
         return self._get('artists/' + trid + '/albums', album_type=album_type,
-            country=country, limit=limit, offset=offset)
+                         country=country, limit=limit, offset=offset)
 
     def artist_top_tracks(self, artist_id, country='US'):
         ''' Get Spotify catalog information about an artist's top 10 tracks
@@ -298,7 +298,8 @@ class Spotify(object):
         '''
 
         trid = self._get_id('album', album_id)
-        return self._get('albums/' + trid + '/tracks/', limit=limit, offset=offset)
+        return self._get('albums/' + trid + '/tracks/', limit=limit,
+                         offset=offset)
 
     def albums(self, albums):
         ''' returns a list of albums given the album IDs, URIs, or URLs
@@ -338,22 +339,23 @@ class Spotify(object):
                 - limit  - the number of items to return
                 - offset - the index of the first item to return
         '''
-        return self._get("users/%s/playlists" % user, limit=limit, offset=offset)
+        return self._get("users/%s/playlists" % user, limit=limit,
+                         offset=offset)
 
-    def user_playlist(self, user, playlist_id = None, fields=None):
+    def user_playlist(self, user, playlist_id=None, fields=None):
         ''' Gets playlist of a user
             Parameters:
                 - user - the id of the user
                 - playlist_id - the id of the playlist
                 - fields - which fields to return
         '''
-        if playlist_id == None:
+        if playlist_id is None:
             return self._get("users/%s/starred" % (user), fields=fields)
         plid = self._get_id('playlist', playlist_id)
         return self._get("users/%s/playlists/%s" % (user, plid), fields=fields)
 
-    def user_playlist_tracks(self, user, playlist_id = None, fields=None,
-        limit=100, offset=0):
+    def user_playlist_tracks(self, user, playlist_id=None, fields=None,
+                             limit=100, offset=0):
         ''' Get full details of the tracks of a playlist owned by a user.
 
             Parameters:
@@ -365,7 +367,7 @@ class Spotify(object):
         '''
         plid = self._get_id('playlist', playlist_id)
         return self._get("users/%s/playlists/%s/tracks" % (user, plid),
-                    limit=limit, offset=offset, fields=fields)
+                         limit=limit, offset=offset, fields=fields)
 
     def user_playlist_create(self, user, name, public=True):
         ''' Creates a playlist for a user
@@ -375,8 +377,8 @@ class Spotify(object):
                 - name - the name of the playlist
                 - public - is the created playlist public
         '''
-        data = {'name':name, 'public':public }
-        return self._post("users/%s/playlists" % (user,), payload = data)
+        data = {'name': name, 'public': public}
+        return self._post("users/%s/playlists" % (user,), payload=data)
 
     def user_playlist_change_details(
             self, user, playlist_id, name=None, public=None):
@@ -397,7 +399,7 @@ class Spotify(object):
                          payload=data)
 
     def user_playlist_add_tracks(self, user, playlist_id, tracks,
-                position=None):
+                                 position=None):
         ''' Adds tracks to a playlist
 
             Parameters:
@@ -407,9 +409,9 @@ class Spotify(object):
                 - position - the position to add the tracks
         '''
         plid = self._get_id('playlist', playlist_id)
-        ftracks = [ self._get_uri('track', tid) for tid in tracks]
-        return self._post("users/%s/playlists/%s/tracks" % (user,plid),
-             payload = ftracks, position=position)
+        ftracks = [self._get_uri('track', tid) for tid in tracks]
+        return self._post("users/%s/playlists/%s/tracks" % (user, plid),
+                          payload=ftracks, position=position)
 
     def user_playlist_replace_tracks(self, user, playlist_id, tracks):
         ''' Replace all tracks in a playlist
@@ -420,13 +422,14 @@ class Spotify(object):
                 - tracks - the list of track ids to add to the playlist
         '''
         plid = self._get_id('playlist', playlist_id)
-        ftracks = [ self._get_uri('track', tid) for tid in tracks]
-        payload = { "uris": ftracks }
-        return self._put("users/%s/playlists/%s/tracks" % (user,plid),
-                payload = payload)
+        ftracks = [self._get_uri('track', tid) for tid in tracks]
+        payload = {"uris": ftracks}
+        return self._put("users/%s/playlists/%s/tracks" % (user, plid),
+                         payload=payload)
 
-    def user_playlist_reorder_tracks(self, user, playlist_id, range_start, insert_before,
-                        range_length=1, snapshot_id=None):
+    def user_playlist_reorder_tracks(
+            self, user, playlist_id, range_start, insert_before,
+            range_length=1, snapshot_id=None):
         ''' Reorder tracks in a playlist
 
             Parameters:
@@ -438,16 +441,16 @@ class Spotify(object):
                 - snapshot_id - optional playlist's snapshot ID
         '''
         plid = self._get_id('playlist', playlist_id)
-        payload = { "range_start": range_start,
-                    "range_length": range_length,
-                    "insert_before": insert_before }
+        payload = {"range_start": range_start,
+                   "range_length": range_length,
+                   "insert_before": insert_before}
         if snapshot_id:
             payload["snapshot_id"] = snapshot_id
-        return self._put("users/%s/playlists/%s/tracks" % (user,plid),
-                payload = payload)
+        return self._put("users/%s/playlists/%s/tracks" % (user, plid),
+                         payload=payload)
 
-    def user_playlist_remove_all_occurrences_of_tracks(self, user, playlist_id,
-                        tracks, snapshot_id=None):
+    def user_playlist_remove_all_occurrences_of_tracks(
+            self, user, playlist_id, tracks, snapshot_id=None):
         ''' Removes all occurrences of the given tracks from the given playlist
 
             Parameters:
@@ -459,15 +462,15 @@ class Spotify(object):
         '''
 
         plid = self._get_id('playlist', playlist_id)
-        ftracks = [ self._get_uri('track', tid) for tid in tracks]
-        payload = { "tracks": [ {"uri": track} for track in ftracks] }
+        ftracks = [self._get_uri('track', tid) for tid in tracks]
+        payload = {"tracks": [{"uri": track} for track in ftracks]}
         if snapshot_id:
             payload["snapshot_id"] = snapshot_id
         return self._delete("users/%s/playlists/%s/tracks" % (user, plid),
-                payload = payload)
+                            payload=payload)
 
-    def user_playlist_remove_specific_occurrences_of_tracks(self, user,
-            playlist_id, tracks, snapshot_id=None):
+    def user_playlist_remove_specific_occurrences_of_tracks(
+            self, user, playlist_id, tracks, snapshot_id=None):
         ''' Removes all occurrences of the given tracks from the given playlist
 
             Parameters:
@@ -486,11 +489,11 @@ class Spotify(object):
                 "uri": self._get_uri("track", tr["uri"]),
                 "positions": tr["positions"],
             })
-        payload = { "tracks": ftracks }
+        payload = {"tracks": ftracks}
         if snapshot_id:
             payload["snapshot_id"] = snapshot_id
         return self._delete("users/%s/playlists/%s/tracks" % (user, plid),
-                payload = payload)
+                            payload=payload)
 
     def me(self):
         ''' Get detailed profile information about the current user.
@@ -525,7 +528,7 @@ class Spotify(object):
 
         '''
         return self._get('me/tracks', limit=limit, offset=offset)
-    
+
     def current_user_followed_artists(self, limit=20, after=None):
         ''' Gets a list of the artists followed by the current authorized user
 
@@ -534,64 +537,73 @@ class Spotify(object):
                 - after - ghe last artist ID retrieved from the previous request
 
         '''
-        return self._get('me/following', type='artist', limit=limit, after=after)
+        return self._get('me/following', type='artist', limit=limit,
+                         after=after)
 
-    def current_user_saved_tracks_delete(self, tracks=[]):
+    def current_user_saved_tracks_delete(self, tracks=None):
         ''' Remove one or more tracks from the current user's
             "Your Music" library.
 
             Parameters:
                 - tracks - a list of track URIs, URLs or IDs
         '''
-        tlist = [self._get_id('track', t) for t in tracks]
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id('track', t) for t in tracks]
         return self._delete('me/tracks/?ids=' + ','.join(tlist))
 
-    def current_user_saved_tracks_contains(self, tracks=[]):
+    def current_user_saved_tracks_contains(self, tracks=None):
         ''' Check if one or more tracks is already saved in
             the current Spotify user’s “Your Music” library.
 
             Parameters:
                 - tracks - a list of track URIs, URLs or IDs
         '''
-        tlist = [self._get_id('track', t) for t in tracks]
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id('track', t) for t in tracks]
         return self._get('me/tracks/contains?ids=' + ','.join(tlist))
 
-
-    def current_user_saved_tracks_add(self, tracks=[]):
+    def current_user_saved_tracks_add(self, tracks=None):
         ''' Add one or more tracks to the current user's
             "Your Music" library.
 
             Parameters:
                 - tracks - a list of track URIs, URLs or IDs
         '''
-        tlist = [self._get_id('track', t) for t in tracks]
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id('track', t) for t in tracks]
         return self._put('me/tracks/?ids=' + ','.join(tlist))
 
-    def current_user_top_artists(self, limit=20, offset=0, time_range='medium_term'):
+    def current_user_top_artists(self, limit=20, offset=0,
+                                 time_range='medium_term'):
         ''' Get the current user's top artists
 
             Parameters:
                 - limit - the number of entities to return
                 - offset - the index of the first entity to return
-                - time_range - Over what time frame are the affinities computed.
+                - time_range - Over what time frame are the affinities computed
                   Valid-values: short_term, medium_term, long_term
         '''
-        return self._get('me/top/artists', time_range=time_range, limit=limit,offset=offset)
+        return self._get('me/top/artists', time_range=time_range, limit=limit,
+                         offset=offset)
 
-    def current_user_top_tracks(self, limit=20, offset=0, time_range='medium_term'):
+    def current_user_top_tracks(self, limit=20, offset=0,
+                                time_range='medium_term'):
         ''' Get the current user's top tracks
 
             Parameters:
                 - limit - the number of entities to return
                 - offset - the index of the first entity to return
-                - time_range - Over what time frame are the affinities computed.
+                - time_range - Over what time frame are the affinities computed
                   Valid-values: short_term, medium_term, long_term
         '''
-        return self._get('me/top/tracks', time_range=time_range, limit=limit,offset=offset)
+        return self._get('me/top/tracks', time_range=time_range, limit=limit,
+                         offset=offset)
 
-
-    def featured_playlists(self, locale=None, country=None,
-            timestamp=None, limit=20, offset = 0):
+    def featured_playlists(self, locale=None, country=None, timestamp=None,
+                           limit=20, offset=0):
         ''' Get a list of Spotify featured playlists
 
             Parameters:
@@ -614,9 +626,10 @@ class Spotify(object):
                   items.
         '''
         return self._get('browse/featured-playlists', locale=locale,
-            country=country, timestamp=timestamp, limit=limit, offset=offset)
+                         country=country, timestamp=timestamp, limit=limit,
+                         offset=offset)
 
-    def new_releases(self,  country=None, limit=20, offset = 0):
+    def new_releases(self, country=None, limit=20, offset=0):
         ''' Get a list of new album releases featured in Spotify
 
             Parameters:
@@ -629,10 +642,10 @@ class Spotify(object):
                   (the first object). Use with limit to get the next set of
                   items.
         '''
-        return self._get('browse/new-releases', country=country,
-            limit=limit, offset=offset)
+        return self._get('browse/new-releases', country=country, limit=limit,
+                         offset=offset)
 
-    def categories(self,  country=None, locale=None, limit=20, offset = 0):
+    def categories(self, country=None, locale=None, limit=20, offset=0):
         ''' Get a list of new album releases featured in Spotify
 
             Parameters:
@@ -649,9 +662,10 @@ class Spotify(object):
                   items.
         '''
         return self._get('browse/categories', country=country, locale=locale,
-            limit=limit, offset=offset)
+                         limit=limit, offset=offset)
 
-    def category_playlists(self,  category_id=None, country=None, limit=20, offset = 0):
+    def category_playlists(self, category_id=None, country=None, limit=20,
+                           offset=0):
         ''' Get a list of new album releases featured in Spotify
 
             Parameters:
@@ -666,11 +680,11 @@ class Spotify(object):
                   (the first object). Use with limit to get the next set of
                   items.
         '''
-        return self._get('browse/categories/' + category_id + '/playlists', country=country, 
-            limit=limit, offset=offset)
+        return self._get('browse/categories/' + category_id + '/playlists',
+                         country=country, limit=limit, offset=offset)
 
-    def recommendations(self, seed_artists=[], seed_genres=[], seed_tracks=[],
-        limit = 20, country=None, **kwargs):
+    def recommendations(self, seed_artists=None, seed_genres=None,
+                        seed_tracks=None, limit=20, country=None, **kwargs):
         ''' Get a list of recommended tracks for one to five seeds.
 
             Parameters:
@@ -678,40 +692,43 @@ class Spotify(object):
 
                 - seed_tracks - a list of artist IDs, URIs or URLs
 
-                - seed_genres - a list of genre names. Available genres for 
+                - seed_genres - a list of genre names. Available genres for
                   recommendations can be found by calling recommendation_genre_seeds
 
-                - country - An ISO 3166-1 alpha-2 country code. If provided, all 
+                - country - An ISO 3166-1 alpha-2 country code. If provided, all
                   results will be playable in this country.
 
                 - limit - The maximum number of items to return. Default: 20.
                   Minimum: 1. Maximum: 100
 
-                - min/max/target_<attribute> - For the tuneable track attributes listed 
+                - min/max/target_<attribute> - For the tuneable track attributes listed
                   in the documentation, these values provide filters and targeting on
                   results.
         '''
         params = dict(limit=limit)
         if seed_artists:
-            params['seed_artists'] = [self._get_id('artist', a) for a in seed_artists]
+            params['seed_artists'] = [self._get_id('artist', a)
+                                      for a in seed_artists]
         if seed_genres:
             params['seed_genres'] = seed_genres
         if seed_tracks:
-            params['seed_tracks'] = [self._get_id('track', t) for t in seed_tracks]
+            params['seed_tracks'] = [self._get_id('track', t)
+                                     for t in seed_tracks]
         if country:
             params['market'] = country
 
-        for attribute in ["acousticness", "danceability", "duration_ms", "energy", 
-            "instrumentalness", "key", "liveness", "loudness", "mode", "popularity",
-            "speechiness", "tempo", "time_signature", "valence"]:
+        for attribute in ["acousticness", "danceability", "duration_ms",
+                          "energy", "instrumentalness", "key", "liveness",
+                          "loudness", "mode", "popularity", "speechiness",
+                          "tempo", "time_signature", "valence"]:
             for prefix in ["min_", "max_", "target_"]:
                 param = prefix + attribute
                 if param in kwargs:
                     params[param] = kwargs[param]
-        return self._get('recommendations', **params)   
+        return self._get('recommendations', **params)
 
     def recommendation_genre_seeds(self):
-        ''' Get a list of genres available for the recommendations function. 
+        ''' Get a list of genres available for the recommendations function.
         '''
         return self._get('recommendations/available-genre-seeds')
 
@@ -721,7 +738,7 @@ class Spotify(object):
                 - tracks - a list of track URIs, URLs or IDs, maximum: 50 ids
         '''
         tlist = [self._get_id('track', t) for t in tracks]
-        results =  self._get('audio-features?ids=' + ','.join(tlist))
+        results = self._get('audio-features?ids=' + ','.join(tlist))
         # the response has changed, look for the new style first, and if
         # its not there, fallback on the old style
         if 'audio_features' in results:
@@ -733,15 +750,15 @@ class Spotify(object):
         fields = id.split(':')
         if len(fields) >= 3:
             if type != fields[-2]:
-                self._warn('expected id of type ' + type + ' but found type ' \
-                        + fields[2] + " " + id)
+                self._warn('expected id of type %s but found type %s %s',
+                           type, fields[-2], id)
             return fields[-1]
         fields = id.split('/')
         if len(fields) >= 3:
             itype = fields[-2]
             if type != itype:
-                self._warn('expected id of type ' + type + ' but found type ' \
-                        + itype + " " + id)
+                self._warn('expected id of type %s but found type %s %s',
+                           type, itype, id)
             return fields[-1]
         return id
 


### PR DESCRIPTION
I added support for the API endpoint [here](https://developer.spotify.com/web-api/change-playlist-details/) which allows for the modification of playlist details such as the name and whether the playlist is marked as public and/or collaborative.

I also did some general cleanup. In a few cases, this included modifying args defaulted to mutable values (mostly `arg=[]`) to avoid the pitfalls described [here](https://pythonconquerstheuniverse.wordpress.com/2012/02/15/mutable-default-arguments/).

Please review: @plamere 
