### PR TITLE
Make special-members only show __init__

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -252,7 +252,7 @@ API Reference
 .. automodule:: spotipy.client
     :members:
     :undoc-members:
-    :special-members:
+    :special-members: __init__
     :show-inheritance:
 
 :mod:`oauth2` Module
@@ -261,7 +261,7 @@ API Reference
 .. automodule:: spotipy.oauth2
     :members:
     :undoc-members:
-    :special-members:
+    :special-members: __init__
     :show-inheritance:
 
 :mod:`util` Module
@@ -270,7 +270,7 @@ API Reference
 .. automodule:: spotipy.util
     :members:
     :undoc-members:
-    :special-members:
+    :special-members: __init__
     :show-inheritance:
 
 


### PR DESCRIPTION
Whoops! special-members shows *all* special members, including __dict__, which is unnecessary to document. This makes it only show __init__.