### PR TITLE
Get new access token 60 seconds before old one times out

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -78,7 +78,7 @@ class SpotifyClientCredentials(object):
 
     def _is_token_expired(self, token_info):
         now = int(time.time())
-        return token_info['expires_at'] < now
+        return token_info['expires_at'] - now < 60
 
     def _add_custom_values_to_token_info(self, token_info):
         """


### PR DESCRIPTION
On prolonged interactions with the Spotify API, I was running into token timeout errors. I think this was due to the gap between `_is_token_expired` call and the subsequent GET request sometimes being longer than the time left before token expiry. Returning True if the number of seconds between token timeout and current time was less than 60 solved the problem.
