### PR TITLE
add support /me/playlists method

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -331,7 +331,7 @@ class Spotify(object):
         '''
         return self._get('users/' + user)
 
-    def me_playlists(self, limit=50, offset=0):
+    def current_user_playlists(self, limit=50, offset=0):
         """ Get current user playlists without required getting his profile
             Parameters:
                 - limit  - the number of items to return

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -21,6 +21,7 @@ class SpotifyException(Exception):
         return 'http status: {0}, code:{1} - {2}'.format(
             self.http_status, self.code, self.msg)
 
+
 class Spotify(object):
     '''
         Example usage::
@@ -329,6 +330,14 @@ class Spotify(object):
                 - user - the id of the usr
         '''
         return self._get('users/' + user)
+
+    def me_playlists(self, limit=50, offset=0):
+        """ Get current user playlists without required getting his profile
+            Parameters:
+                - limit  - the number of items to return
+                - offset - the index of the first item to return
+        """
+        return self._get("me/playlists", limit=limit, offset=offset)
 
     def user_playlists(self, user, limit=50, offset=0):
         ''' Gets playlists of a user


### PR DESCRIPTION
A shortcut for API at https://developer.spotify.com/web-api/get-a-list-of-current-users-playlists/

So that we can get the current user playlist without require to know current user info
