### PR TITLE
Swap use of subprocess.call for webbrowser.open in util.py

### DIFF
--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -3,9 +3,9 @@
 
 from __future__ import print_function
 import os
-import subprocess
 from . import oauth2
 import spotipy
+import webbrowser
 
 def prompt_for_user_token(username, scope=None, client_id = None,
         client_secret = None, redirect_uri = None):
@@ -67,8 +67,8 @@ def prompt_for_user_token(username, scope=None, client_id = None,
         ''')
         auth_url = sp_oauth.get_authorize_url()
         try:
-            subprocess.call(["open", auth_url])
-            print("Opening %s in your browser" % auth_url)
+            webbrowser.open(auth_url)
+            print("Opened %s in your browser" % auth_url)
         except:
             print("Please navigate here: %s" % auth_url)
 


### PR DESCRIPTION
This swaps out the subprocess call to "open {uri}" to use the webbrowser module, which is more portable. I wrote this after noticing that my client (Linux on amd64) didn't properly open my browser when it printed the message about doing so.