### PR TITLE
Add support for public playlists

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -675,6 +675,18 @@ class Spotify(object):
         r = self._put('me/albums?ids=' + ','.join(alist))
         return r
 
+    def public_playlist(self, user, playlist_id):
+        ''' Return public playlist, given the owner user ID 
+            and playlist ID 
+
+		    Parameters:
+		        - user - playlist owner's User ID
+		        - playlist_id - playlist URI string
+        '''
+
+        plid = self._get_id('playlist', playlist_id)
+        return self._get('users/' + user + '/playlists/' + plid)
+
     def featured_playlists(self, locale=None, country=None, timestamp=None,
                            limit=20, offset=0):
         ''' Get a list of Spotify featured playlists


### PR DESCRIPTION
Allow the ability to get information from a public playlist. In order to do this, you must have the User ID of the playlist owner, and the playlist ID (both of these can be found in the playlist URL). 

This is achieved through the added public_playlist function. Usage example, where sp is the spotipy.Spotify object :

```
playlist = sp.public_playlist(EXAMPLE_USER_ID, EXAMPLE_PLAYLIST_ID)
playlistTracks = playlist['tracks']['items']
for item in playlistTracks:
    print(item['track']['id'])
```

Example above will print the track ID for every song in that playlist

