### PR TITLE
Fixes error when scope is not set

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -149,8 +149,10 @@ class SpotifyOAuth(object):
                 pass
 
     def _is_scope_subset(self, needle_scope, haystack_scope):
-        needle_scope = set(needle_scope.split())
-        haystack_scope = set(haystack_scope.split())
+        if needle_scope:
+            needle_scope = set(needle_scope.split())
+        if haystack_scope:
+            haystack_scope = set(haystack_scope.split())
 
         return needle_scope <= haystack_scope
 


### PR DESCRIPTION
If scope is set to `None` spotipy throws this error:

```
  File "/home/josduj/.local/lib/python2.7/site-packages/spotipy/oauth2.py", line 157, in _is_scope_subset
    needle_scope = set(needle_scope.split())
AttributeError: 'NoneType' object has no attribute 'split'
```