### PR TITLE
Add cache_path as an argument to prompt_for_user_token()

### DIFF
--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -8,7 +8,7 @@ import spotipy
 import webbrowser
 
 def prompt_for_user_token(username, scope=None, client_id = None,
-        client_secret = None, redirect_uri = None):
+        client_secret = None, redirect_uri = None, cache_path = None):
     ''' prompts the user to login if necessary and returns
         the user token suitable for use with the spotipy.Spotify 
         constructor
@@ -20,6 +20,7 @@ def prompt_for_user_token(username, scope=None, client_id = None,
          - client_id - the client id of your app
          - client_secret - the client secret of your app
          - redirect_uri - the redirect URI of your app
+         - cache_path - path to location to save tokens
 
     '''
 
@@ -46,8 +47,9 @@ def prompt_for_user_token(username, scope=None, client_id = None,
         ''')
         raise spotipy.SpotifyException(550, -1, 'no credentials set')
 
+    cache_path = cache_path or ".cache-" + username
     sp_oauth = oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri, 
-        scope=scope, cache_path=".cache-" + username )
+        scope=scope, cache_path=cache_path)
 
     # try to get a valid token for this user, from the cache,
     # if not in the cache, the create a new (this will send


### PR DESCRIPTION
Fixes #167 

This allows overriding the default relative location of `cache_path` when calling `prompt_for_user_token()`. External scripts will be able to avoid creating a `.cache-username` file in whatever directory the user happens to be in when the script is ran.

I personally think `cache_path` should default to `os.path.join(os.path.expanduser('~'), '.cache-' + username)` so `cache_path` always references the same file in the user's `$HOME`, but that would probably break a lot of existing users.