### PR TITLE
Fix execution on headless systems where webbrowser module may not be available

### DIFF
--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 import os
 from . import oauth2
 import spotipy
-import webbrowser
 
 def prompt_for_user_token(username, scope=None, client_id = None,
         client_secret = None, redirect_uri = None):
@@ -67,6 +66,7 @@ def prompt_for_user_token(username, scope=None, client_id = None,
         ''')
         auth_url = sp_oauth.get_authorize_url()
         try:
+            import webbrowser
             webbrowser.open(auth_url)
             print("Opened %s in your browser" % auth_url)
         except:


### PR DESCRIPTION
On several headless systems (including but not limited to optware, entware packages for NASs, routers, etc), python builds do not include webbrowser module to save space since there's no browser on these systems. 
As mentioned in #170, currently spotipy does not run on these systems because it fails in the import statement. This fix will allow spotipy to run well on headless systems as well.
I've tested it to work on my linux PC as well as on my Asus routers (optware and entware) and Synology NAS (entware and synology python).