### PR TITLE
Playlist description support

### DIFF
--- a/examples/change_playlist_details.py
+++ b/examples/change_playlist_details.py
@@ -19,9 +19,13 @@ if len(sys.argv) > 3:
     if len(sys.argv) > 5:
         collaborative = sys.argv[5].lower() == 'true'
 
+    description = None
+    if len(sys.argv) > 6:
+        description = sys.argv[6]
+
 else:
-    print ("Usage: %s username playlist_id name [public collaborative]" %
-           (sys.argv[0]))
+    print ("Usage: %s username playlist_id name [public collaborative "
+           "description]" % (sys.argv[0]))
     sys.exit()
 
 scope = 'playlist-modify-public playlist-modify-private'
@@ -32,7 +36,7 @@ if token:
     sp.trace = False
     results = sp.user_playlist_change_details(
         username, playlist_id, name=name, public=public,
-        collaborative=collaborative)
+        collaborative=collaborative, description=description)
     print results
 else:
     print "Can't get token for", username

--- a/examples/create_playlist.py
+++ b/examples/create_playlist.py
@@ -12,8 +12,9 @@ import spotipy.util as util
 if len(sys.argv) > 2:
     username = sys.argv[1]
     playlist_name = sys.argv[2]
+    playlist_description = sys.argv[3]
 else:
-    print("Usage: %s username playlist-name" % (sys.argv[0],))
+    print("Usage: %s username playlist-name playlist-description" % (sys.argv[0],))
     sys.exit()
 
 token = util.prompt_for_user_token(username)
@@ -21,7 +22,8 @@ token = util.prompt_for_user_token(username)
 if token:
     sp = spotipy.Spotify(auth=token)
     sp.trace = False
-    playlists = sp.user_playlist_create(username, playlist_name)
+    playlists = sp.user_playlist_create(username, playlist_name,
+                                        playlist_description)
     pprint.pprint(playlists)
 else:
     print("Can't get token for", username)

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -399,20 +399,21 @@ class Spotify(object):
                          limit=limit, offset=offset, fields=fields,
                          market=market)
 
-    def user_playlist_create(self, user, name, public=True):
+    def user_playlist_create(self, user, name, public=True, description=''):
         ''' Creates a playlist for a user
 
             Parameters:
                 - user - the id of the user
                 - name - the name of the playlist
                 - public - is the created playlist public
+                - description - the description of the playlist
         '''
-        data = {'name': name, 'public': public}
+        data = {'name': name, 'public': public, 'description': description}
         return self._post("users/%s/playlists" % (user,), payload=data)
 
     def user_playlist_change_details(
             self, user, playlist_id, name=None, public=None,
-            collaborative=None):
+            collaborative=None, description=None):
         ''' Changes a playlist's name and/or public/private state
 
             Parameters:
@@ -421,6 +422,7 @@ class Spotify(object):
                 - name - optional name of the playlist
                 - public - optional is the playlist public
                 - collaborative - optional is the playlist collaborative
+                - description - optional description of the playlist
         '''
         data = {}
         if isinstance(name, six.string_types):
@@ -429,6 +431,8 @@ class Spotify(object):
             data['public'] = public
         if isinstance(collaborative, bool):
             data['collaborative'] = collaborative
+        if isinstance(description, six.string_types):
+            data['description'] = description
         return self._put("users/%s/playlists/%s" % (user, playlist_id),
                          payload=data)
 


### PR DESCRIPTION
I added support for the description field which was newly added to the [create playlist](https://developer.spotify.com/web-api/create-playlist/) and [update playlist details](https://developer.spotify.com/web-api/change-playlist-details/#disqus_thread) endpoints. I also modified the related examples to include this new field.

A test for this endpoint would require someone maintaining a playlist strictly for running the test and then having the test run as the playlist owner, so I have not included a test for this change.

Please review: @plamere 