### PR TITLE
Add show_dialog auth url option

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -163,7 +163,7 @@ class SpotifyOAuth(object):
     def is_token_expired(self, token_info):
         return is_token_expired(token_info)
 
-    def get_authorize_url(self, state=None):
+    def get_authorize_url(self, state=None, show_dialog=False):
         """ Gets the URL to use to authorize this app
         """
         payload = {'client_id': self.client_id,
@@ -175,6 +175,8 @@ class SpotifyOAuth(object):
             state = self.state
         if state is not None:
             payload['state'] = state
+        if show_dialog:
+            payload['show_dialog'] = True
 
         urlparams = urllibparse.urlencode(payload)
 

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -146,6 +146,24 @@ class TestSpotifyOAuth(unittest.TestCase):
         parsed_qs = urllibparse.parse_qs(parsed_url.query)
         self.assertEqual(parsed_qs['state'][0], state)
 
+    def test_get_authorize_url_does_not_show_dialog_by_default(self):
+        oauth = SpotifyOAuth("CLID", "CLISEC", "REDIR")
+
+        url = oauth.get_authorize_url()
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertNotIn('show_dialog', parsed_qs)
+
+    def test_get_authorize_url_shows_dialog_when_requested(self):
+        oauth = SpotifyOAuth("CLID", "CLISEC", "REDIR")
+
+        url = oauth.get_authorize_url(show_dialog=True)
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertTrue(parsed_qs['show_dialog'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Optional. Whether or not to force the user to approve the app again if they’ve already done so. If false (default), a user who has already approved the application may be automatically redirected to the URI specified by redirect_uri. If true, the user will not be automatically redirected and will have to approve the app again.

From https://developer.spotify.com/web-api/authorization-guide/