### PR TITLE
Remove unnecessary token_info parameter for oauth2.SpotifyClientCredentials methods

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -81,11 +81,12 @@ class SpotifyClientCredentials(object):
     def is_token_expired(self):
         return is_token_expired(self.token_info)
 
-    def _add_custom_values_to_token_info(self, token_info):
+    def _add_custom_values_to_token_info(self):
         """
         Store some values that aren't directly provided by a Web API
         response.
         """
+        token_info = self.token_info
         token_info['expires_at'] = int(time.time()) + token_info['expires_in']
         return token_info
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -78,8 +78,8 @@ class SpotifyClientCredentials(object):
         token_info = response.json()
         return token_info
 
-    def is_token_expired(self, token_info):
-        return is_token_expired(token_info)
+    def is_token_expired(self):
+        return is_token_expired(self.token_info)
 
     def _add_custom_values_to_token_info(self, token_info):
         """


### PR DESCRIPTION
This PR removes the necessity of passing `token_info` parameter to `oauth2.SpotifyClientCredentials.is_token_expired()` to know if the token has expired or not.