### PR TITLE
Fixes typo on recommendations usage comment

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -801,7 +801,7 @@ class Spotify(object):
             Parameters:
                 - seed_artists - a list of artist IDs, URIs or URLs
 
-                - seed_tracks - a list of artist IDs, URIs or URLs
+                - seed_tracks - a list of track IDs, URIs or URLs
 
                 - seed_genres - a list of genre names. Available genres for
                   recommendations can be found by calling recommendation_genre_seeds


### PR DESCRIPTION
On the parameters list, seed_tracks had the same description as seed_artists.
Changed: "artist" -> "track"