### PR TITLE
Fix prompt_for_user_token parameter strings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,7 +127,7 @@ To support the **Authorization Code Flow** *Spotipy* provides a
 utility method ``util.prompt_for_user_token`` that will attempt to authorize the
 user.  You can pass your app credentials directly into the method as arguments::
 
-    util.prompt_for_user_token(username,scope,client_id='your-app-redirect-url',client_secret='your-app-redirect-url',redirect_uri='your-app-redirect-url')
+    util.prompt_for_user_token(username,scope,client_id='your-app-client-id',client_secret='your-app-client-secret',redirect_uri='your-app-redirect-url')
 
 or if you are reluctant to immortalize your app credentials in your source code, 
 you can set environment variables like so::


### PR DESCRIPTION
The client-id and client-secret had 'your-app-redirect-uri' when they should be 'your-app-client-id' and 'your-app-client-secret' respectively.