### PR TITLE
Support for using before and after cursors with recently played tracks

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -681,12 +681,22 @@ class Spotify(object):
         return self._get('me/top/tracks', time_range=time_range, limit=limit,
                          offset=offset)
 
-    def current_user_recently_played(self, limit=50):
+    def current_user_recently_played(self, limit=50, cursor_type=None, timestamp=0):
         ''' Get the current user's recently played tracks
 
             Parameters:
                 - limit - the number of entities to return
-        '''        
+                - cursor_type - either "after" to get all items after timestamp or
+                  "before" to use all values before the timestamp.
+                - timestamp - A Unix timestamp in milliseconds.
+        '''
+
+        if cursor_type == "after":
+            return self._get('me/player/recently-played', limit=limit, after=timestamp)
+
+        if cursor_type == "before":
+            return self._get('me/player/recently-played', limit=limit, before=timestamp)
+
         return self._get('me/player/recently-played', limit=limit)
 
     def current_user_saved_albums_add(self, albums=[]):


### PR DESCRIPTION
Added support for supplying a cursor timestamp when listing recently played tracks. Either an "after" timestamp or a "before" timestamp can be supplied, in which case the recently played tracks after or before the given timestamp respectively are returned by the API. See the [documentation](https://beta.developer.spotify.com/documentation/web-api/reference/player/get-recently-played/).