### PR TITLE
Spin up a local webserver to record login url

### DIFF
--- a/examples/local_webserver_login.py
+++ b/examples/local_webserver_login.py
@@ -1,0 +1,28 @@
+import pprint
+import sys
+
+import spotipy
+import spotipy.util as util
+import simplejson as json
+
+if len(sys.argv) > 1:
+    username = sys.argv[1]
+else:
+    print("Usage: %s username" % (sys.argv[0],))
+    sys.exit()
+
+scope = 'user-top-read'
+token = util.prompt_for_user_token(username, scope, local_webserver=True)
+
+if token:
+    sp = spotipy.Spotify(auth=token)
+    sp.trace = False
+    ranges = ['short_term', 'medium_term', 'long_term']
+    for range in ranges:
+        print("range:", range)
+        results = sp.current_user_top_tracks(time_range=range, limit=50)
+        for i, item in enumerate(results['items']):
+            print(i, item['name'], '//', item['artists'][0]['name'])
+
+else:
+    print("Can't get token for", username)


### PR DESCRIPTION
Rather than making the user always copy and paste a link, add the option to
start a local http server to accept the Spotify redirect url.

Tested with new examples/local_webserver_login.py and also verified that
examples/my_top_tracks.py still worked.