### PR TITLE
Adding position_ms to start_playback

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -189,6 +189,16 @@ class Spotify(object):
             kwargs.update(args)
         return self._internal_call('PUT', url, payload, kwargs)
 
+    def get_auth(self):
+        """ returns the authorization object associated with this client
+        """
+        return self._auth
+
+    def set_auth(self, auth):
+        """ returns the authorization object associated with this client
+        """
+        self._auth = auth
+
     def next(self, result):
         """ returns the next result given a paged result
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -914,7 +914,7 @@ class Spotify(object):
         }
         return self._put("me/player", payload=data)
 
-    def start_playback(self, device_id = None, context_uri = None, uris = None, offset = None):
+    def start_playback(self, device_id = None, context_uri = None, uris = None, offset = None, position_ms = None):
         ''' Start or resume user's playback.
 
             Provide a `context_uri` to start playback or a album,
@@ -945,6 +945,8 @@ class Spotify(object):
             data['uris'] = uris
         if offset is not None:
             data['offset'] = offset
+        if position_ms is not None:
+            data['position_ms'] = position_ms
         return self._put(self._append_device_id("me/player/play", device_id), payload=data)
 
     def pause_playback(self, device_id = None):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -686,7 +686,7 @@ class Spotify(object):
 
             Parameters:
                 - limit - the number of entities to return
-        '''        
+        '''
         return self._get('me/player/recently-played', limit=limit)
 
     def current_user_saved_albums_add(self, albums=[]):
@@ -1024,6 +1024,17 @@ class Spotify(object):
             return
         state = str(state).lower()
         self._put(self._append_device_id("me/player/shuffle?state=%s" % state, device_id))
+
+
+    def playlist(self, playlist_id):
+        #return self._get('playlists/%s' % playlist_id)
+        actual_id = self._get_id('playlist', playlist_id)
+        return self._get('playlists/' + actual_id)
+
+    def playlist_tracks(self, playlist_id):
+        actual_id = self._get_id('playlist', playlist_id)
+        return self._get('playlists/%s/tracks' % actual_id)
+
 
     def _append_device_id(self, path, device_id):
         ''' Append device ID to API path.

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -142,7 +142,7 @@ class SpotifyOAuth(object):
                     token_info = self.refresh_access_token(token_info['refresh_token'])
 
             except IOError as e:
-                raise e
+                pass
 
         return token_info
 

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -9,7 +9,7 @@ import spotipy
 def prompt_for_user_token(username, scope=None, client_id = None,
         client_secret = None, redirect_uri = None, cache_path = None):
     ''' prompts the user to login if necessary and returns
-        the user token suitable for use with the spotipy.Spotify 
+        the user token suitable for use with the spotipy.Spotify
         constructor
 
         Parameters:
@@ -41,13 +41,13 @@ def prompt_for_user_token(username, scope=None, client_id = None,
             export SPOTIPY_CLIENT_SECRET='your-spotify-client-secret'
             export SPOTIPY_REDIRECT_URI='your-app-redirect-url'
 
-            Get your credentials at     
+            Get your credentials at
                 https://developer.spotify.com/my-applications
         ''')
         raise spotipy.SpotifyException(550, -1, 'no credentials set')
 
     cache_path = cache_path or ".cache-" + username
-    sp_oauth = oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri, 
+    sp_oauth = oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri,
         scope=scope, cache_path=cache_path)
 
     # try to get a valid token for this user, from the cache,
@@ -82,12 +82,12 @@ def prompt_for_user_token(username, scope=None, client_id = None,
             response = input("Enter the URL you were redirected to: ")
 
         print()
-        print() 
+        print()
 
         code = sp_oauth.parse_response_code(response)
         token_info = sp_oauth.get_access_token(code)
     # Auth'ed API request
     if token_info:
-        return token_info['access_token']
+        return (token_info['access_token'], sp_oauth)
     else:
         return None


### PR DESCRIPTION
The [API reference](https://developer.spotify.com/documentation/web-api/reference/player/start-a-users-playback/) says you can pass in a parameter, `position_ms`, when starting or resuming playback. 

I added it in my own fork so I could switch to a track and seek in just one request. It might be useful for others. 