### PR TITLE
requests_cache compatibility

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -128,7 +128,8 @@ class Spotify(object):
                 raise SpotifyException(r.status_code,
                     -1, '%s:\n %s' % (r.url, 'error'), headers=r.headers)
         finally:
-            r.connection.close()
+            if hasattr(r, "connection"):
+                r.connection.close()
         if r.text and len(r.text) > 0 and r.text != 'null':
             results = r.json()
             if self.trace:  # pragma: no cover


### PR DESCRIPTION
When using [requests_cache](https://github.com/reclosedev/requests-cache), the cached request does not have a _connection_ attribute. Explicitly checking for it before closing the connection enables use of _requests_cache_.