### PR TITLE
Add two missing api endpoints relating to playlists

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -579,7 +579,8 @@ class Spotify(object):
             - limit: maximum number of tracks to return
             - offset: index of the first track to return
         """
-        return self._get("playlists/{}/tracks?limit={}&offset={}".format(playlist_id, limit, offset))
+        plid = self._get_id('playlist', playlist_id)
+        return self._get("playlists/{}/tracks?limit={}&offset={}".format(plid, limit, offset))
 
     def get_playlist(self, playlist_id):
         """
@@ -589,7 +590,8 @@ class Spotify(object):
         Parameters:
             - playlist_id: the id of the playlist
         """
-        return self._get("playlists/{}".format(playlist_id))
+        plid = self._get_id('playlist', playlist_id)
+        return self._get("playlists/{}".format(plid))
 
     def me(self):
         """ Get detailed profile information about the current user.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -569,6 +569,27 @@ class Spotify(object):
         """
         return self._get("users/{}/playlists/{}/followers/contains?ids={}".format(playlist_owner_id, playlist_id, ','.join(user_ids)))
 
+    def get_playlist_tracks(self, playlist_id=None):
+        """
+        Get full details of the tracks of a playlist owned by a Spotify user. Link to api doc as of 08/17/2019:
+            - https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlists-tracks/
+
+        Parameters:
+            - playlist_id: the id of the playlist
+
+        """
+        return self._get("playlists/{}/tracks".format(playlist_id))
+
+    def get_playlist(self, playlist_id):
+        """
+        Get a playlist owned by a spotify user. Link to api doc as of 08/17/2019:
+            - https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist/
+
+        Parameters:
+            - playlist_id: the id of the playlist
+        """
+        return self._get("playlists/{}".format(playlist_id))
+
     def me(self):
         """ Get detailed profile information about the current user.
             An alias for the 'current_user' method.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -569,16 +569,17 @@ class Spotify(object):
         """
         return self._get("users/{}/playlists/{}/followers/contains?ids={}".format(playlist_owner_id, playlist_id, ','.join(user_ids)))
 
-    def get_playlist_tracks(self, playlist_id=None):
+    def get_playlist_tracks(self, playlist_id, limit=100, offset=0):
         """
         Get full details of the tracks of a playlist owned by a Spotify user. Link to api doc as of 08/17/2019:
             - https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlists-tracks/
 
         Parameters:
             - playlist_id: the id of the playlist
-
+            - limit: maximum number of tracks to return
+            - offset: index of the first track to return
         """
-        return self._get("playlists/{}/tracks".format(playlist_id))
+        return self._get("playlists/{}/tracks?limit={}&offset={}".format(playlist_id, limit, offset))
 
     def get_playlist(self, playlist_id):
         """


### PR DESCRIPTION
Two endpoints to get playist info and track. Difference between this one
and other playlist endpoints is that they don't require you to provide
a user_id