### PR TITLE
Mistake in docstring

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -507,7 +507,7 @@ class Spotify(object):
             Parameters:
                 - user - the id of the user
                 - playlist_id - the id of the playlist
-                - tracks - the list of track ids to add to the playlist
+                - tracks - the list of track ids to remove from the playlist
                 - snapshot_id - optional id of the playlist snapshot
 
         """


### PR DESCRIPTION
user_playlist_remove_all_occurrences_of_tracks' docstring says "add to the playlist" instead of "remove from the playlist" in the description of the parameters.