### PR TITLE
Trim '?<key>' when extracting ID from HTTP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+ - Fixed inconsistent behaviour with some API methods when
+   a full HTTP URL is passed.
+
 ### Changed
  - Fixed invalid calls to logging warn method
  - `mock` no longer needed for install. Only used in `tox`.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1128,7 +1128,7 @@ class Spotify(object):
             if type != itype:
                 self._warn('expected id of type %s but found type %s %s' %
                            (type, itype, id))
-            return fields[-1]
+            return fields[-1].split('?')[0]
         return id
 
     def _get_uri(self, type, id):


### PR DESCRIPTION
If this excess part isn't trimmed from the ID, it can cause unexpected
results when calling some API methods.

For example; this code now correctly returns all albums for an artist:
```
artist = 'https://open.spotify.com/artist/7oPftvlwr6VrsViSDV7fJY?si=M3PrzRC4TBOZu8YyLYc-tA'
artist_albums = sp.artist_albums(artist)
```

Previously, this code mimicked same behaviour as calling
`spotify.artist`, but now will return albums as expected
with this commit.

Fixes #365 and #323.