### PR TITLE
Automatic refresh of Authorization Code Flow Tokens in long-running Applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ - Auto-Refresh token in long-running apps when using Authorization Code Flow
+
 ## [2.7.1] - 2020-01-20
 
 ### Changed

--- a/examples/long_running.py
+++ b/examples/long_running.py
@@ -1,0 +1,32 @@
+# long running example (need to be authenticated via oauth)
+
+import sys
+import time
+from datetime import datetime
+
+import spotipy
+import spotipy.util as util
+
+if len(sys.argv) > 1:
+    username = sys.argv[1]
+else:
+    print("Whoops, need your username!")
+    print("usage: python user_playlists.py [username]")
+    sys.exit()
+
+SCOPE = 'user-modify-playback-state,user-read-playback-state,user-read-currently-playing'
+oauth = util.prompt_for_user_token(username, redirect_uri="http://localhost/", scope=SCOPE)
+
+if oauth:
+    sp = spotipy.Spotify(auth=oauth)
+    # sp.trace = True
+    # sp.trace_out = True
+    start = datetime.now()
+    while True:
+        current_playback = sp.current_playback()
+        print(datetime.now() - start, "is_playing?",
+              None if current_playback is None else current_playback['is_playing'])
+
+        time.sleep(60)
+else:
+    print("Can't get token for", username)

--- a/examples/long_running.py
+++ b/examples/long_running.py
@@ -14,8 +14,16 @@ else:
     print("usage: python user_playlists.py [username]")
     sys.exit()
 
-SCOPE = 'user-modify-playback-state,user-read-playback-state,user-read-currently-playing'
-oauth = util.prompt_for_user_token(username, redirect_uri="http://localhost/", scope=SCOPE)
+SCOPE = ','.join([
+    'user-modify-playback-state',
+    'user-read-playback-state',
+    'user-read-currently-playing'
+])
+
+oauth = util.prompt_for_user_token(
+    username,
+    redirect_uri="http://localhost/",
+    scope=SCOPE)
 
 if oauth:
     sp = spotipy.Spotify(auth=oauth)
@@ -24,8 +32,10 @@ if oauth:
     start = datetime.now()
     while True:
         current_playback = sp.current_playback()
-        print(datetime.now() - start, "is_playing?",
-              None if current_playback is None else current_playback['is_playing'])
+        print(datetime.now() - start,
+              "is_playing?",
+              None if current_playback is None
+              else current_playback['is_playing'])
 
         time.sleep(60)
 else:

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -63,7 +63,7 @@ class Spotify(object):
         """
         Creates a Spotify API client.
 
-        :param auth: An authorization token (optional)
+        :param auth: An authenticated OAuth2 Instance
         :param requests_session:
             A Requests session object or a truthy value to create one.
             A falsy value disables sessions.
@@ -94,7 +94,8 @@ class Spotify(object):
 
     def _auth_headers(self):
         if self._auth:
-            return {'Authorization': 'Bearer {0}'.format(self._auth)}
+            token_info = self._auth.get_cached_token()
+            return {'Authorization': 'Bearer {0}'.format(token_info['access_token'])}
         elif self.client_credentials_manager:
             token = self.client_credentials_manager.get_access_token()
             return {'Authorization': 'Bearer {0}'.format(token)}

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -95,7 +95,8 @@ class Spotify(object):
     def _auth_headers(self):
         if self._auth:
             token_info = self._auth.get_cached_token()
-            return {'Authorization': 'Bearer {0}'.format(token_info['access_token'])}
+            access_token = token_info['access_token']
+            return {'Authorization': 'Bearer {0}'.format(access_token)}
         elif self.client_credentials_manager:
             token = self.client_credentials_manager.get_access_token()
             return {'Authorization': 'Bearer {0}'.format(token)}

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -16,7 +16,6 @@ import sys
 import time
 
 import requests
-
 # Workaround to support both python 2 & 3
 import six
 import six.moves.urllib.parse as urllibparse
@@ -135,32 +134,41 @@ class SpotifyOAuth(object):
         self.cache_path = cache_path
         self.scope = self._normalize_scope(scope)
         self.proxies = proxies
+        self.token_info = None
 
     def get_cached_token(self):
         ''' Gets a cached auth token
         '''
-        token_info = None
+        if self.token_info is not None:
+            if self.is_token_expired(self.token_info):
+                self.token_info = self.refresh_access_token(
+                    self.token_info['refresh_token'])
+
+            return self.token_info
+
         if self.cache_path:
             try:
                 f = open(self.cache_path)
                 token_info_string = f.read()
                 f.close()
-                token_info = json.loads(token_info_string)
+                self.token_info = json.loads(token_info_string)
 
                 # if scopes don't match, then bail
-                if 'scope' not in token_info or not self._is_scope_subset(
-                        self.scope, token_info['scope']):
+                if 'scope' not in self.token_info or not self._is_scope_subset(
+                        self.scope, self.token_info['scope']):
                     return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info['refresh_token'])
+                if self.is_token_expired(self.token_info):
+                    self.token_info = self.refresh_access_token(
+                        self.token_info['refresh_token'])
 
             except IOError:
                 pass
-        return token_info
+
+        return self.token_info
 
     def _save_token_info(self, token_info):
+        self.token_info = token_info
         if self.cache_path:
             try:
                 f = open(self.cache_path, 'w')

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -140,10 +140,7 @@ class SpotifyOAuth(object):
         ''' Gets a cached auth token
         '''
         if self.token_info is not None:
-            if self.is_token_expired(self.token_info):
-                self.token_info = self.refresh_access_token(
-                    self.token_info['refresh_token'])
-
+            self._refresh_token_if_expired()
             return self.token_info
 
         if self.cache_path:
@@ -158,14 +155,17 @@ class SpotifyOAuth(object):
                         self.scope, self.token_info['scope']):
                     return None
 
-                if self.is_token_expired(self.token_info):
-                    self.token_info = self.refresh_access_token(
-                        self.token_info['refresh_token'])
+                self._refresh_token_if_expired()
 
             except IOError:
                 pass
 
         return self.token_info
+
+    def _refresh_token_if_expired(self):
+        if self.is_token_expired(self.token_info):
+            self.token_info = self.refresh_access_token(
+                self.token_info['refresh_token'])
 
     def _save_token_info(self, token_info):
         self.token_info = token_info

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -103,9 +103,7 @@ def prompt_for_user_token(username, scope=None, client_id=None,
         print()
 
         code = sp_oauth.parse_response_code(response)
-        token_info = sp_oauth.get_access_token(code)
+        sp_oauth.get_access_token(code)
+
     # Auth'ed API request
-    if token_info:
-        return token_info['access_token']
-    else:
-        return None
+    return sp_oauth


### PR DESCRIPTION
This PR implements automatic refreshing of Authorization Code Flow Tokens.
Currently an `access_token` requested via the Authorization Code Flow have a lifetime of 3600 seconds (1 hour) after which a new `access_token` needs to be requested using the 'refresh_token`.

The Logic in `util.prompt_for_user_token` looks for a matching set of tokens in the `cache_path` and if none is found, it requests both an `access_token` and a `refresh_token` from Spotify and stores them in the `cache_path`. If one is found, the `access_token` is checked for validity and if it is expired, a new one is requested and updated in the `cache_path`.

This process works fine for short running applications, because the Token is automatically refreshed, whenever `util.prompt_for_user_token` is invoked. For long running applications (with a runtime greater then the remaining lifetime of the `access_token` upon startup) this poses a problem, because the `access_token` is never refreshed, once `util.prompt_for_user_token` has returned.

To refresh the token later, the initialized instance of `oauth2.SpotifyOAuth` is required. This instance is created in `util.prompt_for_user_token` but destroyed when the method returns.

This PR changes the return-value of `util.prompt_for_user_token` to return the initialized `oauth2.SpotifyOAuth` instead of the `access_token`. This instance is accepted as the `auth`-argument to the `spotipy.Spotify` constructor, so code that was just passing the token-string don't have to be changed.

Furthermore `oauth2.SpotifyOAuth` is changed to also cache the `access_token` in-memory, so that accessing it via the oauth2-instance does not have to hit the filesystem.

The method `Spotify._auth_headers` is responsible for adding the Auth-Token to the HTTP Request-Headers. It is changed to actively request a valid `access_token` from the oauth2 instance. The `oauth2.SpotifyOAuth` class is changed to check the validity of the Token before returning and, if required, requesting a new Token.

An Example of a long-running process which before exposed the problem is added. It does not run for multiple hours, refreshing the Token when it has expired before issuing any other request.

This probably fixes #263 and fixes #87
It probably also closes #428 by obsoleting it