### PR TITLE
Updates to Spotify.current_user_recently_played()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
  - Support for `playlist_cover_image`
+ - Support `after` and `before` parameter in `current_user_recently_played`
 
 ## [2.7.1] - 2020-01-20
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -762,7 +762,7 @@ class Spotify(object):
                           Cannot be used if before is specified.
                 - before - unix timestamp in milliseconds. Returns all items 
                            before (but not including) this cursor position.
-                           Cannot be used if after is specified 
+                           Cannot be used if after is specified
         '''
         return self._get('me/player/recently-played', limit=limit, after=after,
                          before=before)

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -751,13 +751,21 @@ class Spotify(object):
         return self._get('me/top/tracks', time_range=time_range, limit=limit,
                          offset=offset)
 
-    def current_user_recently_played(self, limit=50):
+    def current_user_recently_played(self, limit=50, after=None,
+                                     before=None):
         ''' Get the current user's recently played tracks
 
             Parameters:
                 - limit - the number of entities to return
+                - after - unix timestamp in milliseconds. Returns all items 
+                          after (but not including) this cursor position.
+                          Cannot be used if before is specified.
+                - before - unix timestamp in milliseconds. Returns all items 
+                           before (but not including) this cursor position.
+                           Cannot be used if after is specified 
         '''
-        return self._get('me/player/recently-played', limit=limit)
+        return self._get('me/player/recently-played', limit=limit, after=after,
+                         before=before)
 
     def current_user_saved_albums(self, limit=20, offset=0):
         """ Gets a list of the albums saved in the current authorized user's

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -757,10 +757,10 @@ class Spotify(object):
 
             Parameters:
                 - limit - the number of entities to return
-                - after - unix timestamp in milliseconds. Returns all items 
+                - after - unix timestamp in milliseconds. Returns all items
                           after (but not including) this cursor position.
                           Cannot be used if before is specified.
-                - before - unix timestamp in milliseconds. Returns all items 
+                - before - unix timestamp in milliseconds. Returns all items
                            before (but not including) this cursor position.
                            Cannot be used if after is specified
         '''

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,6 +25,7 @@ import sys
 import unittest
 import warnings
 import requests
+from pprint import pprint  # noqa
 
 sys.path.insert(0, os.path.abspath(os.pardir))
 
@@ -88,6 +89,7 @@ class AuthTestSpotipy(unittest.TestCase):
             'user-read-private '
             'user-top-read '
             'user-follow-modify '
+            'user-read-recently-played '
             'ugc-image-upload'
         )
 
@@ -240,6 +242,25 @@ class AuthTestSpotipy(unittest.TestCase):
         response = self.spotify.current_user_top_artists()
         items = response['items']
         self.assertTrue(len(items) > 0)
+
+    def test_current_user_recently_played(self):
+        # No cursor
+        res = self.spotify.current_user_recently_played()
+        self.assertTrue(len(res['items']) <= 50)
+        played_at = res['items'][0]['played_at']
+
+        # Using `before` gives tracks played before
+        res = self.spotify.current_user_recently_played(
+            before=res['cursors']['after'])
+        self.assertTrue(len(res['items']) <= 50)
+        self.assertTrue(res['items'][0]['played_at'] < played_at)
+        played_at = res['items'][0]['played_at']
+
+        # Using `after` gives tracks played after
+        res = self.spotify.current_user_recently_played(
+            after=res['cursors']['before'])
+        self.assertTrue(len(res['items']) <= 50)
+        self.assertTrue(res['items'][0]['played_at'] > played_at)
 
     def test_user_playlist_ops(self):
         sp = self.spotify


### PR DESCRIPTION
Adds **after** and **before** parameters to Spotify.current_user_recently_played method according to the Spotify Developer API documentation: [Get Recently Played](https://developer.spotify.com/documentation/web-api/reference/player/get-recently-played/)