### PR TITLE
Prompt option to always show a dialog when giving permissions to Spotify

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -156,6 +156,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         cache_path=None,
         username=None,
         proxies=None,
+        show_dialog=False
     ):
         """
             Creates a SpotifyOAuth object
@@ -180,6 +181,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         )
         self.scope = self._normalize_scope(scope)
         self.proxies = proxies
+        self.show_dialog = show_dialog
 
     def get_cached_token(self):
         """ Gets a cached auth token
@@ -235,7 +237,7 @@ class SpotifyOAuth(SpotifyAuthBase):
     def is_token_expired(self, token_info):
         return is_token_expired(token_info)
 
-    def get_authorize_url(self, state=None, show_dialog=False):
+    def get_authorize_url(self, state=None):
         """ Gets the URL to use to authorize this app
         """
         payload = {
@@ -249,7 +251,7 @@ class SpotifyOAuth(SpotifyAuthBase):
             state = self.state
         if state is not None:
             payload["state"] = state
-        if show_dialog:
+        if self.show_dialog:
             payload["show_dialog"] = True
 
         urlparams = urllibparse.urlencode(payload)

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -26,6 +26,7 @@ def prompt_for_user_token(
     redirect_uri=None,
     cache_path=None,
     oauth_manager=None,
+    show_dialog=False
 ):
     """ prompts the user to login if necessary and returns
         the user token suitable for use with the spotipy.Spotify
@@ -76,6 +77,7 @@ def prompt_for_user_token(
         redirect_uri,
         scope=scope,
         cache_path=cache_path,
+        show_dialog=show_dialog
     )
 
     # try to get a valid token for this user, from the cache,

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -159,9 +159,9 @@ class TestSpotifyOAuth(unittest.TestCase):
         self.assertNotIn('show_dialog', parsed_qs)
 
     def test_get_authorize_url_shows_dialog_when_requested(self):
-        oauth = SpotifyOAuth("CLID", "CLISEC", "REDIR")
+        oauth = SpotifyOAuth("CLID", "CLISEC", "REDIR", show_dialog=True)
 
-        url = oauth.get_authorize_url(show_dialog=True)
+        url = oauth.get_authorize_url()
 
         parsed_url = urllibparse.urlparse(url)
         parsed_qs = urllibparse.parse_qs(parsed_url.query)


### PR DESCRIPTION
The ```show_dialog``` field is added as an option to util.prompt_for_user_token().

This is necessary if you want to authenticate multiple users in a row