### PR TITLE
Remove unnecessary print statements

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -105,7 +105,6 @@ class SpotifyClientCredentials(SpotifyAuthBase):
                 as a string.
         """
         if as_dict:
-            print("")
             warnings.warn(
                 "You're using 'as_dict = True'."
                 "get_access_token will return the token string directly in future "
@@ -114,7 +113,6 @@ class SpotifyClientCredentials(SpotifyAuthBase):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            print("")
 
         if self.token_info and not self.is_token_expired(self.token_info):
             return self.token_info if as_dict else self.token_info["access_token"]


### PR DESCRIPTION
which show up when fetching access token using:

```python
credentials = oauth2.SpotifyClientCredentials(
    client_id=client_id,
   client_secret=client_secret,
)
token = credentials.get_access_token()
```