### PR TITLE
fixed documentation audio features

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1232,7 +1232,7 @@ class Spotify(object):
     def audio_features(self, tracks=[]):
         """ Get audio features for one or multiple tracks based upon their Spotify IDs
             Parameters:
-                - tracks - a list of track URIs, URLs or IDs, maximum: 50 ids
+                - tracks - a list of track URIs, URLs or IDs, maximum: 100 ids
         """
         if isinstance(tracks, str):
             trackid = self._get_id("track", tracks)


### PR DESCRIPTION
Line 1235: 
OLD - tracks - a list of track URIs, URLs or IDs, maximum: *50* ids
NEW - tracks - a list of track URIs, URLs or IDs, maximum: *100* ids

The maximum for requesting multiple audio features is 100, not 50.
Spotipy is also able to handle a list with 100 items, so it is just a documentation error.

Source: https://developer.spotify.com/documentation/web-api/reference/tracks/get-several-audio-features/