### PR TITLE
user_playlist_add_episodes method was added.

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -683,6 +683,25 @@ class Spotify(object):
             position=position,
         )
 
+    def user_playlist_add_episodes(
+        self, user, playlist_id, episodes, position=None
+    ):
+        """ Adds tracks to a playlist
+
+            Parameters:
+                - user - the id of the user
+                - playlist_id - the id of the playlist
+                - episodes - a list of show episode URIs, URLs or IDs
+                - position - the position to add the tracks
+        """
+        plid = self._get_id("playlist", playlist_id)
+        ftracks = [self._get_uri("episode", tid) for tid in tracks]
+        return self._post(
+            "users/%s/playlists/%s/tracks" % (user, plid),
+            payload=ftracks,
+            position=position,
+        )
+
     def user_playlist_replace_tracks(self, user, playlist_id, tracks):
         """ Replace all tracks in a playlist
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -695,10 +695,10 @@ class Spotify(object):
                 - position - the position to add the tracks
         """
         plid = self._get_id("playlist", playlist_id)
-        ftracks = [self._get_uri("episode", tid) for tid in tracks]
+        fepisodes = [self._get_uri("episode", eid) for tid in episodes]
         return self._post(
             "users/%s/playlists/%s/tracks" % (user, plid),
-            payload=ftracks,
+            payload=fepisodes,
             position=position,
         )
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -695,7 +695,7 @@ class Spotify(object):
                 - position - the position to add the tracks
         """
         plid = self._get_id("playlist", playlist_id)
-        fepisodes = [self._get_uri("episode", eid) for tid in episodes]
+        fepisodes = [self._get_uri("episode", eid) for eid in episodes]
         return self._post(
             "users/%s/playlists/%s/tracks" % (user, plid),
             payload=fepisodes,


### PR DESCRIPTION
Using Spotify APIs on developer console, adding podcast(show) episodes in a user playlist is possible. However, in this version of the repo has only adding tracks into the user playlist method. For my own use, I added a method for this just like already developed for tracks. 