### PR TITLE
Added a method to update the auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 // add new changes here
 
+  - Added a method to update the auth token.
+
 ## [2.11.2] - 2020-04-19
 
 ### Changed

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -101,6 +101,10 @@ class Spotify(object):
             else:  # Use the Requests API module as a "session".
                 self._session = requests.api
 
+    @auth.setter
+    def auth(self, auth):
+        self._auth = auth
+
     @property
     def auth_manager(self):
         return self._auth_manager

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -101,8 +101,7 @@ class Spotify(object):
             else:  # Use the Requests API module as a "session".
                 self._session = requests.api
 
-    @auth.setter
-    def auth(self, auth):
+    def set_auth(self, auth):
         self._auth = auth
 
     @property


### PR DESCRIPTION
Auth token can't currently be updated without creating a new client. this change allows you to continue to use the same client object.