### PR TITLE
Logging regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-// add new changes here
+### Fixed
+
+ - Logging regression due to the addition of `logging.basicConfig()` which was unneeded.
 
 ## [2.11.2] - 2020-04-19
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -14,7 +14,6 @@ import six
 
 from spotipy.exceptions import SpotifyException
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
**Purpose of PR**
 Logging is currently broken for spotipy as noted in issue [478](https://github.com/plamere/spotipy/issues/478). 

**What Was Done**
- Removed unneeded line.

**Other Things to Note**
Tests were passing locally for me, putting up PR in order to test to make sure they pass.