### PR TITLE
In '__init__' super() method should use static class name in SpotifyClientCredentials and SpotifyOAuth

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -112,7 +112,7 @@ class SpotifyClientCredentials(SpotifyAuthBase):
         environment variables
         """
 
-        super(self.__class__, self).__init__(requests_session)
+        super(SpotifyClientCredentials, self).__init__(requests_session)
 
         self.client_id = client_id
         self.client_secret = client_secret
@@ -218,7 +218,7 @@ class SpotifyOAuth(SpotifyAuthBase):
                  - username - username of current client
         """
 
-        super(self.__class__, self).__init__(requests_session)
+        super(SpotifyOAuth, self).__init__(requests_session)
 
         self.client_id = client_id
         self.client_secret = client_secret


### PR DESCRIPTION
Currently it is not possible to extend SpotifyClientCredentials and SpotifyOAuth without overrding completely the `__init__` method and avoid calling `super().__init__()`.

I am not an expert in Python so I could be completely wrong, however from my research this seem to be caused from the fact that in the classes' `__init__` they refer to the dynamic `self.__class__`, which when called by the extending class leads to to an infinite recursion.

This PR fixes the issue by setting the class name statically in the `super()` call.