### PR TITLE
Refactor two unittests that could fail for some users and make them more generic

### DIFF
--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -56,6 +56,8 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         playlists = self.spotify.user_playlists(self.username, limit=5)
         self.assertTrue('items' in playlists)
         for playlist in playlists['items']:
+            if playlist['uri'] != self.new_playlist_uri:
+                continue
             user = playlist['owner']['id']
             pid = playlist['id']
             results = self.spotify.user_playlist_tracks(user, pid)
@@ -323,19 +325,19 @@ class SpotipyFollowApiTests(unittest.TestCase):
 
     def test_user_follows_and_unfollows_artist(self):
         # Initially follows 1 artist
-        res = self.spotify.current_user_followed_artists()
-        self.assertEqual(res['artists']['total'], 1)
+        current_user_followed_artists = self.spotify.current_user_followed_artists()[
+            'artists']['total']
 
         # Follow 2 more artists
         artists = ["6DPYiyq5kWVQS4RGwxzPC7", "0NbfKEOTQCcwd6o7wSDOHI"]
         self.spotify.user_follow_artists(artists)
         res = self.spotify.current_user_followed_artists()
-        self.assertEqual(res['artists']['total'], 3)
+        self.assertEqual(res['artists']['total'], current_user_followed_artists + len(artists))
 
         # Unfollow these 2 artists
         self.spotify.user_unfollow_artists(artists)
         res = self.spotify.current_user_followed_artists()
-        self.assertEqual(res['artists']['total'], 1)
+        self.assertEqual(res['artists']['total'], current_user_followed_artists)
 
     def test_user_follows_and_unfollows_user(self):
         # TODO improve after implementing `me/following/contains`


### PR DESCRIPTION
When I used my user in spotify to run unit tests those unittests have failed. Changes are:

- **test_user_follows_and_unfollows_artist**: get the current number of followed artists, follow some new artists. New number should be the current number plus the number of the new followed artists. Unfollow those artists and check if the number get back again to original.
- **test_user_playlist_tracks**: Between all my playlists check only the playlist created by the test.