### PR TITLE
Refactor SpotifyOauthError class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - ...
 
+## [2.12.1] - 2020-05-28
+
+### Changed
+
+ - Added two new attributes: error and error_description to `SpotifyOauthError` exception class to show
+   authorization/authentication web api errors details.
+
 ## [2.12.0] - 2020-04-26
 
 ### Added

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -32,7 +32,7 @@ class SpotifyOauthError(Exception):
     def __init__(self, message, error=None, error_description=None, *args, **kwargs):
         self.error = error
         self.error_description = error_description
-        super().__init__(message, *args, **kwargs)
+        super(SpotifyOauthError, self).__init__(message, *args, **kwargs)
 
 
 def _make_authorization_headers(client_id, client_secret):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -29,7 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 class SpotifyOauthError(Exception):
-    pass
+    def __init__(self, message, error=None, error_description=None, *args, **kwargs):
+        self.error = error
+        self.error_description = error_description
+        super().__init__(message, *args, **kwargs)
 
 
 def _make_authorization_headers(client_id, client_secret):
@@ -165,7 +168,12 @@ class SpotifyClientCredentials(SpotifyAuthBase):
             timeout=self.requests_timeout,
         )
         if response.status_code != 200:
-            raise SpotifyOauthError(response.reason)
+            error_payload = response.json()
+            raise SpotifyOauthError(
+                'error: {0}, error_description: {1}'.format(
+                    error_payload['error'], error_payload['error_description']),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
         token_info = response.json()
         return token_info
 
@@ -431,7 +439,12 @@ class SpotifyOAuth(SpotifyAuthBase):
             timeout=self.requests_timeout,
         )
         if response.status_code != 200:
-            raise SpotifyOauthError(response.reason)
+            error_payload = response.json()
+            raise SpotifyOauthError(
+                'error: {0}, error_description: {1}'.format(
+                    error_payload['error'], error_payload['error_description']),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
         self._save_token_info(token_info)

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -6,6 +6,7 @@ import unittest
 import six.moves.urllib.parse as urllibparse
 
 from spotipy import SpotifyOAuth
+from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 
 try:
     import unittest.mock as mock
@@ -166,3 +167,9 @@ class TestSpotifyOAuth(unittest.TestCase):
         parsed_url = urllibparse.urlparse(url)
         parsed_qs = urllibparse.parse_qs(parsed_url.query)
         self.assertTrue(parsed_qs['show_dialog'])
+
+    def test_spotify_client_credentials_get_access_token(self):
+        oauth = SpotifyClientCredentials(client_id='ID', client_secret='SECRET')
+        with self.assertRaises(SpotifyOauthError) as error:
+            oauth.get_access_token()
+        self.assertEqual(error.exception.error, 'invalid_client')


### PR DESCRIPTION
- add error and error description to SpotifyOauthError to reflect the data returned by web api when error happens
- unit test to SpotifyClientCredentials.get_access_token is added for invalid client