### PR TITLE
Check the state

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -322,11 +322,11 @@ class SpotifyOAuth(SpotifyAuthBase):
             Parameters:
                 - url - the response url
         """
-        url_split = url.split("?code=")
-        if len(url_split) <= 1:
+        _, code, _ = self.parse_oauth_response_url(url)
+        if code is None:
             return url
         else:
-            return url_split[1].split("&")[0]
+            return code
 
     @staticmethod
     def parse_oauth_response_url(url):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -316,17 +316,18 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         return "%s?%s" % (self.OAUTH_AUTHORIZE_URL, urlparams)
 
-    def parse_response_code(self, url):
-        """ Parse the response code in the given response url
+    @staticmethod
+    def parse_oauth_response_url(url):
+        query_s = urlparse(url).query
+        form = dict(parse_qsl(query_s))
+        return tuple(form.get(param) for param in ['state', 'code', 'error'])
 
-            Parameters:
-                - url - the response url
-        """
-        url_split = url.split("?code=")
-        if len(url_split) <= 1:
-            return url
-        else:
-            return url_split[1].split("&")[0]
+    @staticmethod
+    def _get_user_input(prompt):
+        try:
+            return raw_input(prompt)
+        except NameError:
+            return input(prompt)
 
     def _make_authorization_headers(self):
         return _make_authorization_headers(self.client_id, self.client_secret)
@@ -341,17 +342,19 @@ class SpotifyOAuth(SpotifyAuthBase):
 
     def _get_auth_response_interactive(self):
         self._open_auth_url()
-        try:
-            response = raw_input("Enter the URL you were redirected to: ")
-        except NameError:
-            response = input("Enter the URL you were redirected to: ")
-
-        return self.parse_response_code(response)
+        response = SpotifyOAuth._get_user_input("Enter the URL you were redirected to: ")
+        state, code, _ = SpotifyOAuth.parse_oauth_response_url(response)
+        if self.state is not None and self.state != state:
+            raise SpotifyOauthError("Received inconsistent state from OAuth server.")
+        return code
 
     def _get_auth_response_local_server(self, redirect_port):
         server = start_local_http_server(redirect_port)
         self._open_auth_url()
         server.handle_request()
+
+        if self.state is not None and server.state != self.state:
+            raise SpotifyOauthError("Received inconsistent state from OAuth server.")
 
         if server.auth_code is not None:
             return server.auth_code
@@ -386,11 +389,6 @@ class SpotifyOAuth(SpotifyAuthBase):
                     'complete the authorization')
         return self._get_auth_response_interactive()
 
-    def get_authorization_code(self, response=None):
-        if response:
-            return self.parse_response_code(response)
-        return self.get_auth_response()
-
     def get_access_token(self, code=None, as_dict=True, check_cache=True):
         """ Gets the access token for the app given the code
 
@@ -420,7 +418,7 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         payload = {
             "redirect_uri": self.redirect_uri,
-            "code": code or self.get_authorization_code(),
+            "code": code or self.get_auth_response(),
             "grant_type": "authorization_code",
         }
         if self.scope:
@@ -507,21 +505,19 @@ class SpotifyOAuth(SpotifyAuthBase):
 
 class RequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        query_s = urlparse(self.path).query
-        form = dict(parse_qsl(query_s))
+        state, auth_code, error = SpotifyOAuth.parse_oauth_response_url(self.path)
+        self.server.state = state
+        self.server.auth_code = auth_code
+        self.server.error = error
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
         self.end_headers()
 
-        if "code" in form:
-            self.server.auth_code = form["code"]
-            self.server.error = None
+        if self.server.auth_code:
             status = "successful"
-        elif "error" in form:
-            self.server.error = form["error"]
-            self.server.auth_code = None
-            status = "failed ({})".format(form["error"])
+        elif self.server.error:
+            status = "failed ({})".format(self.server.error)
         else:
             self._write("<html><body><h1>Invalid request</h1></body></html>")
             return

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -316,6 +316,18 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         return "%s?%s" % (self.OAUTH_AUTHORIZE_URL, urlparams)
 
+    def parse_response_code(self, url):
+        """ Parse the response code in the given response url
+
+            Parameters:
+                - url - the response url
+        """
+        url_split = url.split("?code=")
+        if len(url_split) <= 1:
+            return url
+        else:
+            return url_split[1].split("&")[0]
+
     @staticmethod
     def parse_oauth_response_url(url):
         query_s = urlparse(url).query
@@ -388,6 +400,11 @@ class SpotifyOAuth(SpotifyAuthBase):
         logger.info('Paste that url you were directed to in order to '
                     'complete the authorization')
         return self._get_auth_response_interactive()
+
+    def get_authorization_code(self, response=None):
+        if response:
+            return self.parse_response_code(response)
+        return self.get_auth_response()
 
     def get_access_token(self, code=None, as_dict=True, check_cache=True):
         """ Gets the access token for the app given the code

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -25,6 +25,7 @@ def prompt_for_user_token(
     client_id=None,
     client_secret=None,
     redirect_uri=None,
+    state=None,
     cache_path=None,
     oauth_manager=None,
     show_dialog=False
@@ -76,6 +77,7 @@ def prompt_for_user_token(
         client_id,
         client_secret,
         redirect_uri,
+        state=state,
         scope=scope,
         cache_path=cache_path,
         show_dialog=show_dialog


### PR DESCRIPTION
Hello,

The `SpotifyOAuth` class accepts an optional `state` parameter to be added to the authorization URL. However, this parameter wasn't checked when echoed back upon the redirection from Spotify, which pretty much made its usage useless. This PR simply adds the necessary check when `state` is used. I also refactored the extraction of the authentication code from the URL so that it's the same between interactive way and local server way.  

- Verify that the state received alongside the authorization code is consistent with the one that was sent
- Refactor URL parsing for the local server way and the interactive way
- Add tests for interactive way
- Allow `state` to be given to `util.prompt_for_user_token`