### PR TITLE
Support Implicit Grant Authorization Flow (Fix #499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+ - Added `SpotifyImplicitGrant` as an auth manager option. It provides
+ user authentication without a client secret but sacrifices the ability
+   to refresh the token without user input. (However, read the class
+   docstring for security advisory.)
+
+## [2.12.1] - 2020-05-28
+
+### Changed
+
  - Added two new attributes: error and error_description to `SpotifyOauthError` exception class to show
    authorization/authentication web api errors details.
  - Allow extending `SpotifyClientCredentials` and `SpotifyOAuth`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  user authentication without a client secret but sacrifices the ability
    to refresh the token without user input. (However, read the class
    docstring for security advisory.)
-
-## [2.12.1] - 2020-05-28
-
-### Changed
-
  - Added two new attributes: error and error_description to `SpotifyOauthError` exception class to show
    authorization/authentication web api errors details.
  - Allow extending `SpotifyClientCredentials` and `SpotifyOAuth`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  user authentication without a client secret but sacrifices the ability
    to refresh the token without user input. (However, read the class
    docstring for security advisory.)
+ - Added built-in verification of the `state` query parameter
  - Added two new attributes: error and error_description to `SpotifyOauthError` exception class to show
    authorization/authentication web api errors details.
+ - Added `SpotifyStateError` subclass of `SpotifyOauthError`
  - Allow extending `SpotifyClientCredentials` and `SpotifyOAuth`
  - Added the market paramter to `album_tracks`
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -139,11 +139,13 @@ class Spotify(object):
     def _auth_headers(self):
         if self._auth:
             return {"Authorization": "Bearer {0}".format(self._auth)}
-        elif self.auth_manager:
-            token = self.auth_manager.get_access_token(as_dict=False)
-            return {"Authorization": "Bearer {0}".format(token)}
-        else:
+        if not self.auth_manager:
             return {}
+        try:
+            token = self.auth_manager.get_access_token(as_dict=False)
+        except TypeError:
+            token = self.auth_manager.get_access_token()
+        return {"Authorization": "Bearer {0}".format(token)}
 
     def _internal_call(self, method, url, payload, params):
         args = dict(params=params)

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -63,7 +63,8 @@ class Spotify(object):
         :param oauth_manager:
             SpotifyOAuth object
         :param auth_manager:
-            SpotifyOauth object or SpotifyClientCredentials object
+            SpotifyOauth, SpotifyClientCredentials,
+            or SpotifyImplicitGrant object
         :param proxies:
             Definition of proxies (optional).
             See Requests doc https://2.python-requests.org/en/master/user/advanced/#proxies

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -631,7 +631,6 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         return is_token_expired(token_info)
 
     def get_access_token(self,
-                         as_dict=False,
                          state=None,
                          response=None,
                          check_cache=True):
@@ -639,14 +638,10 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
 
         Parameters
         ----------
-        * as_dict: **DO NOT USE**, included for tests compatability
         * state: May be supplied, overrides self.state
         * response: URI with token, can break expiration checks
         * check_cache: Interpreted as boolean
         """
-        if as_dict:
-            return NotImplemented
-
         if check_cache:
             token_info = self.get_cached_token()
             if not (token_info is None or is_token_expired(token_info)):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -639,10 +639,10 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
 
         Parameters
         ----------
-        * as_dict: cannot be True, included for tests compatability
-        * state (keyword): May be supplied, overrides self.state
-        * response (kw): URI with token, can break expiration checks
-        * check_cache (kw): Interpreted as boolean
+        * as_dict: **DO NOT USE**, included for tests compatability
+        * state: May be supplied, overrides self.state
+        * response: URI with token, can break expiration checks
+        * check_cache: Interpreted as boolean
         """
         if as_dict:
             return NotImplemented

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -537,7 +537,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
     exposed. OAuth no longer recommends its use because sensitive
     info (the auth token) can be yanked from the browser address bar or
     history, instead recommending the Auth Code flow with PKCE. However,
-    Spotify [does not support PKCE](https://community.spotify.com/t5/Spotify-for-Developers/Authentication-API-failing-in-production-right-now/m-p/4960693/highlight/true#M234),
+    Spotify [does not support PKCE](https://community.spotify.com/t5/Spotify-for-Developers/Authentication-API-failing-in-production-right-now/m-p/4960693/highlight/true#M234), <!---# noqa: E501-->
     so Implicit Grant is the only viable options for client-side Spotify
     API requests.
     """

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -647,7 +647,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         if as_dict:
             return NotImplemented
-        
+
         if check_cache:
             token_info = self.get_cached_token()
             if not (token_info is None or is_token_expired(token_info)):
@@ -704,7 +704,6 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         if "expires_in" in parsed:
             parsed["expires_in"] = int(parsed["expires_in"])
         return parsed
-
 
     def _open_auth_url(self, state=None):
         auth_url = self.get_authorize_url(state)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -632,7 +632,6 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
 
     def get_access_token(self,
                          as_dict=False,
-                         *,
                          state=None,
                          response=None,
                          check_cache=True):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -601,7 +601,15 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
     def is_token_expired(self, token_info):
         return is_token_expired(token_info)
 
-    def get_access_token(self, *, state=None, response=None, check_cache=True):
+    def get_access_token(self,
+                         as_dict=False,
+                         *,
+                         state=None,
+                         response=None,
+                         check_cache=True):
+        if as_dict:
+            return NotImplemented
+        
         if check_cache:
             token_info = self.get_cached_token()
             if not (token_info is None or is_token_expired(token_info)):

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -26,11 +26,9 @@ def prompt_for_user_token(
     client_id=None,
     client_secret=None,
     redirect_uri=None,
-    state=None,
     cache_path=None,
     oauth_manager=None,
-    show_dialog=False,
-    implicit_grant_manager=None
+    show_dialog=False
 ):
     warnings.warn(
         "'prompt_for_user_token' is deprecated."
@@ -53,10 +51,9 @@ def prompt_for_user_token(
          - cache_path - path to location to save tokens
          - oauth_manager - Oauth manager object.
          - show_dialog - If true, a login prompt always shows
-         - implicit_grant_manager - Auth manager for Implicit Grant flow
 
     """
-    if not (oauth_manager or implicit_grant_manager):
+    if not oauth_manager:
         if not client_id:
             client_id = os.getenv("SPOTIPY_CLIENT_ID")
 
@@ -88,7 +85,6 @@ def prompt_for_user_token(
         client_id,
         client_secret,
         redirect_uri,
-        state=state,
         scope=scope,
         cache_path=cache_path,
         show_dialog=show_dialog
@@ -98,15 +94,13 @@ def prompt_for_user_token(
     # if not in the cache, the create a new (this will send
     # the user to a web page where they can authorize this app)
 
-    token_info = sp_auth.get_cached_token()
+    token_info = sp_oauth.get_cached_token()
 
-    if token_info:
-        return token_info["access_token"]
-    if sp_oauth:
+    if not token_info:
         code = sp_oauth.get_auth_response()
         token = sp_oauth.get_access_token(code, as_dict=False)
     else:
-        token = sp_auth.get_access_token()
+        return token_info["access_token"]
 
     # Auth'ed API request
     if token:

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -29,7 +29,8 @@ def prompt_for_user_token(
     state=None,
     cache_path=None,
     oauth_manager=None,
-    show_dialog=False
+    show_dialog=False,
+    implicit_grant_manager=None
 ):
     warnings.warn(
         "'prompt_for_user_token' is deprecated."
@@ -51,9 +52,11 @@ def prompt_for_user_token(
          - redirect_uri - the redirect URI of your app
          - cache_path - path to location to save tokens
          - oauth_manager - Oauth manager object.
+         - show_dialog - If true, a login prompt always shows
+         - implicit_grant_manager - Auth manager for Implicit Grant flow
 
     """
-    if not oauth_manager:
+    if not (oauth_manager or implicit_grant_manager):
         if not client_id:
             client_id = os.getenv("SPOTIPY_CLIENT_ID")
 
@@ -95,13 +98,15 @@ def prompt_for_user_token(
     # if not in the cache, the create a new (this will send
     # the user to a web page where they can authorize this app)
 
-    token_info = sp_oauth.get_cached_token()
+    token_info = sp_auth.get_cached_token()
 
-    if not token_info:
+    if token_info:
+        return token_info["access_token"]
+    if sp_oauth:
         code = sp_oauth.get_auth_response()
         token = sp_oauth.get_access_token(code, as_dict=False)
     else:
-        return token_info["access_token"]
+        token = sp_auth.get_access_token()
 
     # Auth'ed API request
     if token:

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -398,146 +398,35 @@ class SpotipyPlayerApiTests(unittest.TestCase):
         self.assertGreater(res['items'][0]['played_at'], played_at)
 
 
-class SpotipyPlaylistApiTestIG(SpotipyPlaylistApiTest):
+class SpotipyImplicitGrantTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
-                           "spotify:track:7IHOIqZUUInxjVkko181PB",
-                           "4VrWlk8IQxevMvERoX08iC",
-                           "http://open.spotify.com/track/3cySlItpiPiIAzU3NyHCJf"]
-        cls.other_tracks = ["spotify:track:2wySlB6vMzCbQrRnNGOYKa",
-                            "spotify:track:29xKs5BAHlmlX1u4gzQAbJ",
-                            "spotify:track:1PB7gRWcvefzu7t3LJLUlf"]
-        cls.username = os.getenv(CCEV['client_username'])
-
         scope = (
-            'playlist-modify-public '
-            'user-library-read '
             'user-follow-read '
-            'user-library-modify '
-            'user-read-private '
-            'user-top-read '
             'user-follow-modify '
-            'user-read-recently-played '
-            'ugc-image-upload '
-            'user-read-playback-state'
         )
-
-        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
-
+        auth_manager = SpotifyImplicitGrant(scope=scope,
+                                            cache_path=".cache-implicittest")
         cls.spotify = Spotify(auth_manager=auth_manager)
 
-        cls.new_playlist_name = 'spotipy-playlist-test'
-        cls.new_playlist = helpers.get_spotify_playlist(
-            cls.spotify, cls.new_playlist_name, cls.username) or \
-            helpers.create_spotify_playlist(
-                cls.spotify, cls.new_playlist_name, cls.username)
-        cls.new_playlist_uri = cls.new_playlist['uri']
+    def test_user_follows_and_unfollows_artist(self):
+        # Initially follows 1 artist
+        current_user_followed_artists = self.spotify.current_user_followed_artists()[
+            'artists']['total']
 
+        # Follow 2 more artists
+        artists = ["6DPYiyq5kWVQS4RGwxzPC7", "0NbfKEOTQCcwd6o7wSDOHI"]
+        self.spotify.user_follow_artists(artists)
+        res = self.spotify.current_user_followed_artists()
+        self.assertEqual(res['artists']['total'], current_user_followed_artists + len(artists))
 
-class SpotipyLibraryApiTestsIG(SpotipyLibraryApiTests):
-    @classmethod
-    def setUpClass(cls):
-        cls.four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
-                           "spotify:track:7IHOIqZUUInxjVkko181PB",
-                           "4VrWlk8IQxevMvERoX08iC",
-                           "http://open.spotify.com/track/3cySlItpiPiIAzU3NyHCJf"]
-        cls.album_ids = ["spotify:album:6kL09DaURb7rAoqqaA51KU",
-                         "spotify:album:6RTzC0rDbvagTSJLlY7AKl"]
-        cls.username = os.getenv(CCEV['client_username'])
+        # Unfollow these 2 artists
+        self.spotify.user_unfollow_artists(artists)
+        res = self.spotify.current_user_followed_artists()
+        self.assertEqual(res['artists']['total'], current_user_followed_artists)
 
-        scope = (
-            'playlist-modify-public '
-            'user-library-read '
-            'user-follow-read '
-            'user-library-modify '
-            'user-read-private '
-            'user-top-read '
-            'user-follow-modify '
-            'user-read-recently-played '
-            'ugc-image-upload '
-            'user-read-playback-state'
-        )
-
-        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
-
-        cls.spotify = Spotify(auth_manager=auth_manager)
-
-
-class SpotipyUserApiTestsIG(SpotipyUserApiTests):
-    @classmethod
-    def setUpClass(cls):
-        cls.username = os.getenv(CCEV['client_username'])
-
-        scope = (
-            'playlist-modify-public '
-            'user-library-read '
-            'user-follow-read '
-            'user-library-modify '
-            'user-read-private '
-            'user-top-read '
-            'user-follow-modify '
-            'user-read-recently-played '
-            'ugc-image-upload '
-            'user-read-playback-state'
-        )
-
-        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
-
-        cls.spotify = Spotify(auth_manager=auth_manager)
-
-
-class SpotipyBrowseApiTestsIG(SpotipyBrowseApiTests):
-    @classmethod
-    def setUpClass(cls):
-        username = os.getenv(CCEV['client_username'])
-        os.remove(".cache-" + str(username))  # clear cache
-        auth_manager = SpotifyImplicitGrant(username=username)
-        cls.spotify = Spotify(auth_manager=auth_manager)
-
-
-class SpotipyFollowApiTestsIG(SpotipyFollowApiTests):
-    @classmethod
-    def setUpClass(cls):
-        cls.username = os.getenv(CCEV['client_username'])
-        os.remove(".cache-" + str(cls.username))  # clear cache
-
-        scope = (
-            'playlist-modify-public '
-            'user-library-read '
-            'user-follow-read '
-            'user-library-modify '
-            'user-read-private '
-            'user-top-read '
-            'user-follow-modify '
-            'user-read-recently-played '
-            'ugc-image-upload '
-            'user-read-playback-state'
-        )
-
-        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
-
-        cls.spotify = Spotify(auth_manager=auth_manager)
-
-
-class SpotipyPlayerApiTestsIG(SpotipyPlayerApiTests):
-    @classmethod
-    def setUpClass(cls):
-        cls.username = os.getenv(CCEV['client_username'])
-
-        scope = (
-            'playlist-modify-public '
-            'user-library-read '
-            'user-follow-read '
-            'user-library-modify '
-            'user-read-private '
-            'user-top-read '
-            'user-follow-modify '
-            'user-read-recently-played '
-            'ugc-image-upload '
-            'user-read-playback-state'
-        )
-
-        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
-
-        cls.spotify = Spotify(auth_manager=auth_manager)
+    def test_current_user(self):
+        c_user = self.spotify.current_user()
+        user = self.spotify.user(c_user['id'])
+        self.assertEqual(c_user['display_name'], user['display_name'])
+        

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -429,4 +429,3 @@ class SpotipyImplicitGrantTests(unittest.TestCase):
         c_user = self.spotify.current_user()
         user = self.spotify.user(c_user['id'])
         self.assertEqual(c_user['display_name'], user['display_name'])
-        

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -5,6 +5,7 @@ from spotipy import (
     prompt_for_user_token,
     Spotify,
     SpotifyException,
+    SpotifyImplicitGrant
 )
 import unittest
 import requests
@@ -395,3 +396,148 @@ class SpotipyPlayerApiTests(unittest.TestCase):
             after=res['cursors']['before'])
         self.assertLessEqual(len(res['items']), 50)
         self.assertGreater(res['items'][0]['played_at'], played_at)
+
+
+class SpotipyPlaylistApiTestIG(SpotipyPlaylistApiTest):
+    @classmethod
+    def setUpClass(cls):
+        cls.four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
+                           "spotify:track:7IHOIqZUUInxjVkko181PB",
+                           "4VrWlk8IQxevMvERoX08iC",
+                           "http://open.spotify.com/track/3cySlItpiPiIAzU3NyHCJf"]
+        cls.other_tracks = ["spotify:track:2wySlB6vMzCbQrRnNGOYKa",
+                            "spotify:track:29xKs5BAHlmlX1u4gzQAbJ",
+                            "spotify:track:1PB7gRWcvefzu7t3LJLUlf"]
+        cls.username = os.getenv(CCEV['client_username'])
+
+        scope = (
+            'playlist-modify-public '
+            'user-library-read '
+            'user-follow-read '
+            'user-library-modify '
+            'user-read-private '
+            'user-top-read '
+            'user-follow-modify '
+            'user-read-recently-played '
+            'ugc-image-upload '
+            'user-read-playback-state'
+        )
+
+        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
+
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+        cls.new_playlist_name = 'spotipy-playlist-test'
+        cls.new_playlist = helpers.get_spotify_playlist(
+            cls.spotify, cls.new_playlist_name, cls.username) or \
+            helpers.create_spotify_playlist(
+                cls.spotify, cls.new_playlist_name, cls.username)
+        cls.new_playlist_uri = cls.new_playlist['uri']
+
+
+class SpotipyLibraryApiTestsIG(SpotipyLibraryApiTests):
+    @classmethod
+    def setUpClass(cls):
+        cls.four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
+                           "spotify:track:7IHOIqZUUInxjVkko181PB",
+                           "4VrWlk8IQxevMvERoX08iC",
+                           "http://open.spotify.com/track/3cySlItpiPiIAzU3NyHCJf"]
+        cls.album_ids = ["spotify:album:6kL09DaURb7rAoqqaA51KU",
+                         "spotify:album:6RTzC0rDbvagTSJLlY7AKl"]
+        cls.username = os.getenv(CCEV['client_username'])
+
+        scope = (
+            'playlist-modify-public '
+            'user-library-read '
+            'user-follow-read '
+            'user-library-modify '
+            'user-read-private '
+            'user-top-read '
+            'user-follow-modify '
+            'user-read-recently-played '
+            'ugc-image-upload '
+            'user-read-playback-state'
+        )
+
+        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
+
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+
+class SpotipyUserApiTestsIG(SpotipyUserApiTests):
+    @classmethod
+    def setUpClass(cls):
+        cls.username = os.getenv(CCEV['client_username'])
+
+        scope = (
+            'playlist-modify-public '
+            'user-library-read '
+            'user-follow-read '
+            'user-library-modify '
+            'user-read-private '
+            'user-top-read '
+            'user-follow-modify '
+            'user-read-recently-played '
+            'ugc-image-upload '
+            'user-read-playback-state'
+        )
+
+        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
+
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+
+class SpotipyBrowseApiTestsIG(SpotipyBrowseApiTests):
+    @classmethod
+    def setUpClass(cls):
+        username = os.getenv(CCEV['client_username'])
+        os.remove(".cache-" + str(username))  # clear cache
+        auth_manager = SpotifyImplicitGrant(username=username)
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+
+class SpotipyFollowApiTestsIG(SpotipyFollowApiTests):
+    @classmethod
+    def setUpClass(cls):
+        cls.username = os.getenv(CCEV['client_username'])
+        os.remove(".cache-" + str(cls.username))  # clear cache
+
+        scope = (
+            'playlist-modify-public '
+            'user-library-read '
+            'user-follow-read '
+            'user-library-modify '
+            'user-read-private '
+            'user-top-read '
+            'user-follow-modify '
+            'user-read-recently-played '
+            'ugc-image-upload '
+            'user-read-playback-state'
+        )
+
+        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
+
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+
+class SpotipyPlayerApiTestsIG(SpotipyPlayerApiTests):
+    @classmethod
+    def setUpClass(cls):
+        cls.username = os.getenv(CCEV['client_username'])
+
+        scope = (
+            'playlist-modify-public '
+            'user-library-read '
+            'user-follow-read '
+            'user-library-modify '
+            'user-read-private '
+            'user-top-read '
+            'user-follow-modify '
+            'user-read-recently-played '
+            'ugc-image-upload '
+            'user-read-playback-state'
+        )
+
+        auth_manager = SpotifyImplicitGrant(username=cls.username, scope=scope)
+
+        cls.spotify = Spotify(auth_manager=auth_manager)

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -7,6 +7,7 @@ import six.moves.urllib.parse as urllibparse
 
 from spotipy import SpotifyOAuth, SpotifyImplicitGrant
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
+from spotipy.oauth2 import SpotifyStateError
 
 try:
     import unittest.mock as mock
@@ -203,10 +204,7 @@ class TestSpotifyOAuthGetAuthResponseInteractive(unittest.TestCase):
     def test_get_auth_response_with_inconsistent_state(self, webbrowser_mock, get_user_input_mock):
         oauth = SpotifyOAuth("CLID", "CLISEC", "redir.io", state='wxyz')
 
-        with self.assertRaisesRegexp(
-            SpotifyOauthError,
-            "Received inconsistent state from OAuth server."
-        ):
+        with self.assertRaises(SpotifyStateError):
             oauth.get_auth_response()
 
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -5,7 +5,7 @@ import unittest
 
 import six.moves.urllib.parse as urllibparse
 
-from spotipy import SpotifyOAuth
+from spotipy import SpotifyOAuth, SpotifyImplicitGrant
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 
 try:
@@ -39,6 +39,10 @@ def _token_file(token):
 
 def _make_oauth(*args, **kwargs):
     return SpotifyOAuth("CLID", "CLISEC", "REDIR", "STATE", *args, **kwargs)
+
+
+def _make_implicitgrantauth(*args, **kwargs):
+    return SpotifyImplicitGrant("CLID", "REDIR", "STATE", *args, **kwargs)
 
 
 class OAuthCacheTest(unittest.TestCase):
@@ -213,3 +217,121 @@ class TestSpotifyClientCredentials(unittest.TestCase):
         with self.assertRaises(SpotifyOauthError) as error:
             oauth.get_access_token()
         self.assertEqual(error.exception.error, 'invalid_client')
+
+
+class ImplicitGrantCacheTest(unittest.TestCase):
+
+    @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
+    @patch('spotipy.oauth2.open', create=True)
+    def test_gets_from_cache_path(self, opener, is_token_expired):
+        scope = "playlist-modify-private"
+        path = ".cache-username"
+        tok = _make_fake_token(1, 1, scope)
+
+        opener.return_value = _token_file(json.dumps(tok, ensure_ascii=False))
+        is_token_expired.return_value = False
+
+        spot = _make_implicitgrantauth(scope, path)
+        cached_tok = spot.get_cached_token()
+
+        opener.assert_called_with(path)
+        self.assertIsNotNone(cached_tok)
+
+    @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
+    @patch('spotipy.oauth2.open', create=True)
+    def test_expired_token_returns_none(self, opener, is_token_expired):
+        scope = "playlist-modify-private"
+        path = ".cache-username"
+        expired_tok = _make_fake_token(0, None, scope)
+
+        token_file = _token_file(json.dumps(expired_tok, ensure_ascii=False))
+        opener.return_value = token_file
+
+        spot = _make_implicitgrantauth(scope, path)
+        cached_tok = spot.get_cached_token()
+
+        is_token_expired.assert_called_with(expired_tok)
+        opener.assert_any_call(path)
+        self.assertIsNone(cached_tok)
+
+    @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
+    @patch('spotipy.oauth2.open', create=True)
+    def test_badly_scoped_token_bails(self, opener, is_token_expired):
+        token_scope = "playlist-modify-public"
+        requested_scope = "playlist-modify-private"
+        path = ".cache-username"
+        tok = _make_fake_token(1, 1, token_scope)
+
+        opener.return_value = _token_file(json.dumps(tok, ensure_ascii=False))
+        is_token_expired.return_value = False
+
+        spot = _make_implicitgrantauth(requested_scope, path)
+        cached_tok = spot.get_cached_token()
+
+        opener.assert_called_with(path)
+        self.assertIsNone(cached_tok)
+
+    @patch('spotipy.oauth2.open', create=True)
+    def test_saves_to_cache_path(self, opener):
+        scope = "playlist-modify-private"
+        path = ".cache-username"
+        tok = _make_fake_token(1, 1, scope)
+
+        fi = _fake_file()
+        opener.return_value = fi
+
+        spot = SpotifyImplicitGrant("CLID", "REDIR", "STATE", scope, path)
+        spot._save_token_info(tok)
+
+        opener.assert_called_with(path, 'w')
+        self.assertTrue(fi.write.called)
+
+
+class TestSpotifyImplicitGrant(unittest.TestCase):
+
+    def test_get_authorize_url_doesnt_pass_state_by_default(self):
+        auth = SpotifyImplicitGrant("CLID", "REDIR")
+
+        url = auth.get_authorize_url()
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertNotIn('state', parsed_qs)
+
+    def test_get_authorize_url_passes_state_from_constructor(self):
+        state = "STATE"
+        auth = SpotifyImplicitGrant("CLID", "REDIR", state)
+
+        url = auth.get_authorize_url()
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertEqual(parsed_qs['state'][0], state)
+
+    def test_get_authorize_url_passes_state_from_func_call(self):
+        state = "STATE"
+        auth = SpotifyImplicitGrant("CLID", "REDIR", "NOT STATE")
+
+        url = auth.get_authorize_url(state=state)
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertEqual(parsed_qs['state'][0], state)
+
+    def test_get_authorize_url_does_not_show_dialog_by_default(self):
+        auth = SpotifyImplicitGrant("CLID", "REDIR")
+
+        url = auth.get_authorize_url()
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertNotIn('show_dialog', parsed_qs)
+
+    def test_get_authorize_url_shows_dialog_when_requested(self):
+        auth = SpotifyImplicitGrant("CLID", "REDIR", show_dialog=True)
+
+        url = auth.get_authorize_url()
+
+        parsed_url = urllibparse.urlparse(url)
+        parsed_qs = urllibparse.parse_qs(parsed_url.query)
+        self.assertTrue(parsed_qs['show_dialog'])


### PR DESCRIPTION
The code heavily borrows from the existing user authentication class, and the tests are slightly-modified copies of the SpotifyOAuth tests. All tests passed on 3.7.7