### PR TITLE
enable market parameter for album_tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added two new attributes: error and error_description to `SpotifyOauthError` exception class to show
    authorization/authentication web api errors details.
  - Allow extending `SpotifyClientCredentials` and `SpotifyOAuth`
+ - Added the market paramter to `album_tracks`
 
 ### Deprecated
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -339,7 +339,7 @@ class Spotify(object):
         trid = self._get_id("album", album_id)
         return self._get("albums/" + trid)
 
-    def album_tracks(self, album_id, limit=50, offset=0):
+    def album_tracks(self, album_id, limit=50, offset=0, market=None):
         """ Get Spotify catalog information about an album's tracks
 
             Parameters:
@@ -350,7 +350,7 @@ class Spotify(object):
 
         trid = self._get_id("album", album_id)
         return self._get(
-            "albums/" + trid + "/tracks/", limit=limit, offset=offset
+            "albums/" + trid + "/tracks/", limit=limit, offset=offset, market=market
         )
 
     def albums(self, albums):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -346,6 +346,8 @@ class Spotify(object):
                 - album_id - the album ID, URI or URL
                 - limit  - the number of items to return
                 - offset - the index of the first item to return
+                - market - an ISO 3166-1 alpha-2 country code.
+
         """
 
         trid = self._get_id("album", album_id)


### PR DESCRIPTION
enabling the optional market feature for get_album_tracks API:  https://developer.spotify.com/console/get-album-tracks

Adding in order to get the is_playable field for the track listing, which is not included if market is not set