### PR TITLE
Add support to search multiple markets at once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+### Added
+
+ - Support to search multiple markets at once.
+ - Support to search all available Spotify markets.
+ - Added two unit tests to test the new feature.
+
 
 ## [2.13.0] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Support to search multiple markets at once.
  - Support to search all available Spotify markets.
- - Added two unit tests to test the new feature.
-
 
 ## [2.13.0] - 2020-06-25
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1583,7 +1583,7 @@ class Spotify(object):
             results[type + 's']['items'] += result[type + 's']['items']
             results[type + 's']['total'] += result[type + 's']['total']
             if total and len(results[type + 's']['items']) >= total:
-                # sice 'items' to only include number of results requested
+                # splice 'items' to only include number of results requested
                 results[type + 's']['items'] = results[type + 's']['items'][:total]
                 return results
         return results

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -523,7 +523,7 @@ class Spotify(object):
                            from_token. Can supply list of markets. Pass "ALL" to search all country codes.
                 - total - the total number of results to return if multiple markets are supplied in the search.
         """
-        # if string passed and equals "ALL"
+
         if (isinstance(market, str) and market.upper() == "ALL"):
             warnings.warn(
                 "Searching all markets is poorly performing.",
@@ -531,15 +531,13 @@ class Spotify(object):
             )
             return self._search_multiple_markets(q, limit, offset, type, self.country_codes, total)
 
-        # if list is passed
-        elif isinstance(market, list):
+        elif isinstance(market, list) or isinstance(market, tuple):
             warnings.warn(
                 "Searching multiple markets is poorly performing.",
                 UserWarning,
             )
             return self._search_multiple_markets(q, limit, offset, type, market, total)
 
-        # handle all other cases
         else:
             return self._get(
                 "search", q=q, limit=limit, offset=offset, type=type, market=market

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -34,7 +34,67 @@ class Spotify(object):
     """
     max_retries = 3
     default_retry_codes = (429, 500, 502, 503, 504)
-    country_codes=["AD","AR","AU","AT","BE","BO","BR","BG","CA","CL","CO","CR","CY","CZ","DK","DO","EC","SV","EE","FI","FR","DE","GR","GT","HN","HK","HU","IS","ID","IE","IT","JP","LV","LI","LT","LU","MY","MT","MX","MC","NL","NZ","NI","NO","PA","PY","PE","PH","PL","PT","SG","ES","SK","SE","CH","TW","TR","GB","US","UY"]
+    country_codes = [
+        "AD",
+        "AR",
+        "AU",
+        "AT",
+        "BE",
+        "BO",
+        "BR",
+        "BG",
+        "CA",
+        "CL",
+        "CO",
+        "CR",
+        "CY",
+        "CZ",
+        "DK",
+        "DO",
+        "EC",
+        "SV",
+        "EE",
+        "FI",
+        "FR",
+        "DE",
+        "GR",
+        "GT",
+        "HN",
+        "HK",
+        "HU",
+        "IS",
+        "ID",
+        "IE",
+        "IT",
+        "JP",
+        "LV",
+        "LI",
+        "LT",
+        "LU",
+        "MY",
+        "MT",
+        "MX",
+        "MC",
+        "NL",
+        "NZ",
+        "NI",
+        "NO",
+        "PA",
+        "PY",
+        "PE",
+        "PH",
+        "PL",
+        "PT",
+        "SG",
+        "ES",
+        "SK",
+        "SE",
+        "CH",
+        "TW",
+        "TR",
+        "GB",
+        "US",
+        "UY"]
 
     def __init__(
         self,
@@ -463,11 +523,11 @@ class Spotify(object):
                 - n - return as soon as n options are found
         """
         # if string passed and equals "ALL"
-        if (isinstance(market,str) and market.upper() == "ALL"):
+        if (isinstance(market, str) and market.upper() == "ALL"):
             warnings.warn(
-            "Searching all markets is poorly performing. Try to limit search to a list of markets or a single market.",
-            UserWarning,
-        )
+                "Searching all markets is poorly performing.",
+                UserWarning,
+            )
             results = {
                 type + 's': {
                     'href': [],
@@ -493,11 +553,11 @@ class Spotify(object):
             return results
 
         # if list is passed
-        elif isinstance(market,list):
+        elif isinstance(market, list):
             warnings.warn(
-            "Searching multiple markets is poorly performing. Try to limit search to a single market.",
-            UserWarning,
-        )
+                "Searching multiple markets is poorly performing.",
+                UserWarning,
+            )
             results = {
                 type + 's': {
                     'href': [],
@@ -525,10 +585,9 @@ class Spotify(object):
         # handle all other cases
         else:
             return self._get(
-                    "search", q=q, limit=limit, offset=offset, type=type, market=market
-                )
+                "search", q=q, limit=limit, offset=offset, type=type, market=market
+            )
 
-               
     def user(self, user):
         """ Gets basic profile information about a Spotify User
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1562,7 +1562,7 @@ class Spotify(object):
 
     def _get_uri(self, type, id):
         return "spotify:" + type + ":" + self._get_id(type, id)
-    
+
     def _search_multiple_markets(self, q, limit, offset, type, markets, total):
         results = {
                 type + 's': {
@@ -1586,6 +1586,4 @@ class Spotify(object):
                 # sice 'items' to only include number of results requested
                 results[type + 's']['items'] = results[type + 's']['items'][:total]
                 return results
-        
         return results
-

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 class SpotifyOauthError(Exception):
     """ Error during Auth Code or Implicit Grant flow """
+
     def __init__(self, message, error=None, error_description=None, *args, **kwargs):
         self.error = error
         self.error_description = error_description
@@ -41,6 +42,7 @@ class SpotifyOauthError(Exception):
 
 class SpotifyStateError(SpotifyOauthError):
     """ The state sent and state recieved were different """
+
     def __init__(self, local_state=None, remote_state=None, message=None,
                  error=None, error_description=None, *args, **kwargs):
         if not message:

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -174,6 +174,18 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue('artists' in results)
         self.assertTrue(len(results['artists']['items']) > 0)
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
+    
+    def test_artist_search_with_markets(self):
+        results = self.spotify.search(q='weezer', type='artist', market=['GB','US','AU'])
+        self.assertTrue('artists' in results)
+        self.assertTrue(len(results['artists']['items']) > 0)
+        self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
+    
+    def test_artist_search_with_all_markets(self):
+        results = self.spotify.search(q='weezer', type='artist', market='ALL')
+        self.assertTrue('artists' in results)
+        self.assertTrue(len(results['artists']['items']) > 0)
+        self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
 
     def test_artist_albums(self):
         results = self.spotify.artist_albums(self.weezer_urn)

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -174,13 +174,13 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue('artists' in results)
         self.assertTrue(len(results['artists']['items']) > 0)
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
-    
+
     def test_artist_search_with_markets(self):
-        results = self.spotify.search(q='weezer', type='artist', market=['GB','US','AU'])
+        results = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'])
         self.assertTrue('artists' in results)
         self.assertTrue(len(results['artists']['items']) > 0)
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
-    
+
     def test_artist_search_with_all_markets(self):
         results = self.spotify.search(q='weezer', type='artist', market='ALL')
         self.assertTrue('artists' in results)

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -175,17 +175,30 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(len(results['artists']['items']) > 0)
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
 
-    def test_artist_search_with_markets(self):
-        results = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'])
-        self.assertTrue('artists' in results)
-        self.assertTrue(len(results['artists']['items']) > 0)
-        self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
+    def test_artist_search_with_multiple_markets(self):
+        TOTAL=3
+        results_single = self.spotify.search(q='weezer', type='artist', market='US')
+        results_multiple = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'])
+        results_all = self.spotify.search(q='weezer', type='artist', market="ALL")
+        results_limited = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'], total=TOTAL)
 
-    def test_artist_search_with_all_markets(self):
-        results = self.spotify.search(q='weezer', type='artist', market='ALL')
-        self.assertTrue('artists' in results)
-        self.assertTrue(len(results['artists']['items']) > 0)
-        self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
+        self.assertTrue('artists' in results_multiple)
+        self.assertTrue('artists' in results_all)
+        self.assertTrue('artists' in results_limited)
+
+
+        self.assertTrue(len(results_multiple['artists']['items']) > 0)
+        self.assertTrue(len(results_all['artists']['items']) > 0)
+        self.assertTrue(len(results_limited['artists']['items']) > 0)
+
+        self.assertTrue(len(results_all['artists']['items']) > len(results_multiple['artists']['items']))
+        self.assertTrue(len(results_multiple['artists']['items']) > len(results_single['artists']['items']))
+
+        self.assertTrue(results_multiple['artists']['items'][0]['name'] == 'Weezer')
+        self.assertTrue(results_all['artists']['items'][0]['name'] == 'Weezer')
+        self.assertTrue(results_limited['artists']['items'][0]['name'] == 'Weezer')
+
+        self.assertTrue(len(results_limited['artists']['items']) <= TOTAL)
 
     def test_artist_albums(self):
         results = self.spotify.artist_albums(self.weezer_urn)

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -176,23 +176,26 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
 
     def test_artist_search_with_multiple_markets(self):
-        TOTAL=3
+        TOTAL = 3
         results_single = self.spotify.search(q='weezer', type='artist', market='US')
-        results_multiple = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'])
+        results_multiple = self.spotify.search(q='weezer', type='artist',
+                                               market=['GB', 'US', 'AU'])
         results_all = self.spotify.search(q='weezer', type='artist', market="ALL")
-        results_limited = self.spotify.search(q='weezer', type='artist', market=['GB', 'US', 'AU'], total=TOTAL)
+        results_limited = self.spotify.search(q='weezer', type='artist',
+                                                market=['GB', 'US', 'AU'], total=TOTAL)
 
         self.assertTrue('artists' in results_multiple)
         self.assertTrue('artists' in results_all)
         self.assertTrue('artists' in results_limited)
 
-
         self.assertTrue(len(results_multiple['artists']['items']) > 0)
         self.assertTrue(len(results_all['artists']['items']) > 0)
         self.assertTrue(len(results_limited['artists']['items']) > 0)
 
-        self.assertTrue(len(results_all['artists']['items']) > len(results_multiple['artists']['items']))
-        self.assertTrue(len(results_multiple['artists']['items']) > len(results_single['artists']['items']))
+        self.assertTrue(len(results_all['artists']['items']) >
+                        len(results_multiple['artists']['items']))
+        self.assertTrue(len(results_multiple['artists']['items'])
+                        > len(results_single['artists']['items']))
 
         self.assertTrue(results_multiple['artists']['items'][0]['name'] == 'Weezer')
         self.assertTrue(results_all['artists']['items'][0]['name'] == 'Weezer')

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -184,13 +184,18 @@ class AuthTestSpotipy(unittest.TestCase):
         results_limited = self.spotify.search(q='weezer', type='artist',
                                                 market=['GB', 'US', 'AU'], total=TOTAL)
 
+        results_tuple = self.spotify.search(q='weezer', type='artist',
+                                            market=('GB', 'US', 'AU'), total=TOTAL)
+
         self.assertTrue('artists' in results_multiple)
         self.assertTrue('artists' in results_all)
         self.assertTrue('artists' in results_limited)
+        self.assertTrue('artists' in results_tuple)
 
         self.assertTrue(len(results_multiple['artists']['items']) > 0)
         self.assertTrue(len(results_all['artists']['items']) > 0)
         self.assertTrue(len(results_limited['artists']['items']) > 0)
+        self.assertTrue(len(results_tuple['artists']['items']) > 0)
 
         self.assertTrue(len(results_all['artists']['items']) >
                         len(results_multiple['artists']['items']))
@@ -200,6 +205,7 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results_multiple['artists']['items'][0]['name'] == 'Weezer')
         self.assertTrue(results_all['artists']['items'][0]['name'] == 'Weezer')
         self.assertTrue(results_limited['artists']['items'][0]['name'] == 'Weezer')
+        self.assertTrue(results_tuple['artists']['items'][0]['name'] == 'Weezer')
 
         self.assertTrue(len(results_limited['artists']['items']) <= TOTAL)
 


### PR DESCRIPTION
Resolve issue #525 

## Overview
 - Support to search multiple markets at once by passing in a list.
 - Support to search all available Spotify markets.
 - Added two unit tests to test the new feature.

## Detailed
I reformatted the API interface `search` method. I did notice that all but one method directly returned the result that comes from the `self._get` call, and I wanted to keep this to retain any abstraction, but I couldn't think of a way around it. The new `search` method on the Spotify client keeps all original functionality, but I added in some logic to handle if a user passes in a list of markets to search through. In addition, as referenced in #525, I added in the ability to search **ALL** markets as well as another available parameter `n` that will stop the searching once a given number of results are found.

I really tried to keep the object structure returned from Spotify... So, the final object returned from `search` when multiple markets are passed in will be almost identical to the object returned if one market or no markets are passed in.

To the best of my knowledge, it is the same, except `href` now results in a list of `href`s used for searching.

## Performance Issues
As mentioned by @stephanebruckert, this code performs poorly due to looping through http requests, but I can not think of a way around it.
