### PR TITLE
Fix return object formatting for multi-market searches

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1591,7 +1591,7 @@ class Spotify(object):
 
             count += len(result[first_type]['items'])
             if total and count >= total:
-                return results
+                break
             if total and limit > total - count:
                 # when approaching `total` results, adjust `limit` to not request more
                 # items than needed

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1562,26 +1562,16 @@ class Spotify(object):
         return "spotify:" + type + ":" + self._get_id(type, id)
 
     def _search_multiple_markets(self, q, limit, offset, type, markets, total):
-        results = {
-                type + 's': {
-                    'href': [],
-                    'items': [],
-                    'limit': limit,
-                    'next': None,
-                    'offset': 0,
-                    'previous': None,
-                    'total': 0
-                }
-            }
+        results = {}
         for country in markets:
             result = self._get(
                 "search", q=q, limit=limit, offset=offset, type=type, market=country
             )
-            results[type + 's']['href'].append(result[type + 's']['href'])
-            results[type + 's']['items'] += result[type + 's']['items']
-            results[type + 's']['total'] += result[type + 's']['total']
-            if total and len(results[type + 's']['items']) >= total:
+            results[country] = result
+            if total and len(results[country][type + 's']['items']) >= total:
                 # splice 'items' to only include number of results requested
-                results[type + 's']['items'] = results[type + 's']['items'][:total]
+                results[country][type +
+                                 's']['items'] = results[country][type +
+                                                                  's']['items'][:total]
                 return results
         return results

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1563,15 +1563,14 @@ class Spotify(object):
 
     def _search_multiple_markets(self, q, limit, offset, type, markets, total):
         results = {}
+        types = type + 's'
         for country in markets:
             result = self._get(
                 "search", q=q, limit=limit, offset=offset, type=type, market=country
             )
             results[country] = result
-            if total and len(results[country][type + 's']['items']) >= total:
-                # splice 'items' to only include number of results requested
-                results[country][type +
-                                 's']['items'] = results[country][type +
-                                                                  's']['items'][:total]
+            if total and len(results[country][types]['items']) >= total:
+                # slice 'items' to only include number of results requested
+                results[country][types]['items'] = results[country][types]['items'][:total]
                 return results
         return results

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -514,8 +514,7 @@ class Spotify(object):
             Parameters:
                 - q - the search query (see how to write a query in the
                       official documentation https://developer.spotify.com/documentation/web-api/reference/search/search/)  # noqa
-                - limit  - the number of items to return (min = 1, default = 10, max = 50). If a search is to be done on multiple
-                            markets, then this limit is applied to each market. (e.g. search US, CA, MX each with a limit of 10).
+                - limit  - the number of items to return (min = 1, default = 10, max = 50)
                 - offset - the index of the first item to return
                 - type - the type of item to return. One of 'artist', 'album',
                          'track', 'playlist', 'show', or 'episode'

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1593,7 +1593,8 @@ class Spotify(object):
             if total and count >= total:
                 return results
             if total and limit > total - count:
-                # when approaching `total` results, adjust `limit` to not request more items than needed
+                # when approaching `total` results, adjust `limit` to not request more
+                # items than needed
                 limit = total - count
 
         return results

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -180,13 +180,13 @@ class AuthTestSpotipy(unittest.TestCase):
         countries_list = ['GB', 'US', 'AU']
         countries_tuple = ('GB', 'US', 'AU')
 
-        results_multiple = self.spotify.search(q='weezer', type='artist',
-                                               market=countries_list)
-        results_all = self.spotify.search(q='weezer', type='artist', market="ALL")
-        results_tuple = self.spotify.search(q='weezer', type='artist',
-                                            market=countries_tuple)
-        results_limited = self.spotify.search(q='weezer', type='artist',
-                                                market=countries_list, total=TOTAL)
+        results_multiple = self.spotify.search_markets(q='weezer', type='artist',
+                                                       market=countries_list)
+        results_all = self.spotify.search_markets(q='weezer', type='artist', market="ALL")
+        results_tuple = self.spotify.search_markets(q='weezer', type='artist',
+                                                    market=countries_tuple)
+        results_limited = self.spotify.search_markets(q='weezer', type='artist',
+                                                      market=countries_list, total=TOTAL)
 
         self.assertTrue(
             all('artists' in results_multiple[country] for country in results_multiple))

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -177,37 +177,47 @@ class AuthTestSpotipy(unittest.TestCase):
 
     def test_artist_search_with_multiple_markets(self):
         TOTAL = 3
-        results_single = self.spotify.search(q='weezer', type='artist', market='US')
+        countries_list = ['GB', 'US', 'AU']
+        countries_tuple = ('GB', 'US', 'AU')
+
         results_multiple = self.spotify.search(q='weezer', type='artist',
-                                               market=['GB', 'US', 'AU'])
+                                               market=countries_list)
         results_all = self.spotify.search(q='weezer', type='artist', market="ALL")
-        results_limited = self.spotify.search(q='weezer', type='artist',
-                                                market=['GB', 'US', 'AU'], total=TOTAL)
-
         results_tuple = self.spotify.search(q='weezer', type='artist',
-                                            market=('GB', 'US', 'AU'), total=TOTAL)
+                                            market=countries_tuple)
+        results_limited = self.spotify.search(q='weezer', type='artist',
+                                                market=countries_list, total=TOTAL)
 
-        self.assertTrue('artists' in results_multiple)
-        self.assertTrue('artists' in results_all)
-        self.assertTrue('artists' in results_limited)
-        self.assertTrue('artists' in results_tuple)
+        self.assertTrue(
+            all('artists' in results_multiple[country] for country in results_multiple))
+        self.assertTrue(all('artists' in results_all[country] for country in results_all))
+        self.assertTrue(all('artists' in results_tuple[country] for country in results_tuple))
+        self.assertTrue(all('artists' in results_limited[country] for country in results_limited))
 
-        self.assertTrue(len(results_multiple['artists']['items']) > 0)
-        self.assertTrue(len(results_all['artists']['items']) > 0)
-        self.assertTrue(len(results_limited['artists']['items']) > 0)
-        self.assertTrue(len(results_tuple['artists']['items']) > 0)
+        self.assertTrue(
+            all(len(results_multiple[country]['artists']['items']) > 0 for country in
+                results_multiple))
+        self.assertTrue(all(len(results_all[country]['artists']
+                                ['items']) > 0 for country in results_all))
+        self.assertTrue(
+            all(len(results_tuple[country]['artists']['items']) > 0 for country in results_tuple))
+        self.assertTrue(
+            all(len(results_limited[country]['artists']['items']) > 0 for country in
+                results_limited))
 
-        self.assertTrue(len(results_all['artists']['items']) >
-                        len(results_multiple['artists']['items']))
-        self.assertTrue(len(results_multiple['artists']['items'])
-                        > len(results_single['artists']['items']))
+        self.assertTrue(all(results_multiple[country]['artists']['items']
+                            [0]['name'] == 'Weezer' for country in results_multiple))
+        self.assertTrue(all(results_all[country]['artists']['items']
+                            [0]['name'] == 'Weezer' for country in results_all))
+        self.assertTrue(all(results_tuple[country]['artists']['items']
+                            [0]['name'] == 'Weezer' for country in results_tuple))
+        self.assertTrue(all(results_limited[country]['artists']['items']
+                            [0]['name'] == 'Weezer' for country in results_limited))
 
-        self.assertTrue(results_multiple['artists']['items'][0]['name'] == 'Weezer')
-        self.assertTrue(results_all['artists']['items'][0]['name'] == 'Weezer')
-        self.assertTrue(results_limited['artists']['items'][0]['name'] == 'Weezer')
-        self.assertTrue(results_tuple['artists']['items'][0]['name'] == 'Weezer')
-
-        self.assertTrue(len(results_limited['artists']['items']) <= TOTAL)
+        total_limited_results = 0
+        for country in results_limited:
+            total_limited_results += len(results_limited[country]['artists']['items'])
+        self.assertTrue(total_limited_results <= TOTAL)
 
     def test_artist_albums(self):
         results = self.spotify.artist_albums(self.weezer_urn)

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -176,17 +176,17 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertTrue(results['artists']['items'][0]['name'] == 'Weezer')
 
     def test_artist_search_with_multiple_markets(self):
-        TOTAL = 3
+        total = 5
         countries_list = ['GB', 'US', 'AU']
         countries_tuple = ('GB', 'US', 'AU')
 
         results_multiple = self.spotify.search_markets(q='weezer', type='artist',
-                                                       market=countries_list)
-        results_all = self.spotify.search_markets(q='weezer', type='artist', market="ALL")
+                                                       markets=countries_list)
+        results_all = self.spotify.search_markets(q='weezer', type='artist')
         results_tuple = self.spotify.search_markets(q='weezer', type='artist',
-                                                    market=countries_tuple)
-        results_limited = self.spotify.search_markets(q='weezer', type='artist',
-                                                      market=countries_list, total=TOTAL)
+                                                    markets=countries_tuple)
+        results_limited = self.spotify.search_markets(q='weezer', limit=3, type='artist',
+                                                      markets=countries_list, total=total)
 
         self.assertTrue(
             all('artists' in results_multiple[country] for country in results_multiple))
@@ -217,7 +217,7 @@ class AuthTestSpotipy(unittest.TestCase):
         total_limited_results = 0
         for country in results_limited:
             total_limited_results += len(results_limited[country]['artists']['items'])
-        self.assertTrue(total_limited_results <= TOTAL)
+        self.assertTrue(total_limited_results <= total)
 
     def test_artist_albums(self):
         results = self.spotify.artist_albums(self.weezer_urn)


### PR DESCRIPTION
I implemented the changes we discussed in #526. Now, the return object will be a dictionary with keys corresponding to the markets specified in the search with the response from Spotify stored in those keys. I also updated all of my unit tests to reflect these changes