### PR TITLE
Allow for total headless mode by instructing the user to open the URL in a browser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Support to search multiple markets at once.
  - Support to search all available Spotify markets.
+ - Allow for headless OAuth 2.0 authorization by instructing the user to open the URL in a browser.
+
 
 ## [2.13.0] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Support to search multiple markets at once.
  - Support to search all available Spotify markets.
- - Allow for headless OAuth 2.0 authorization by instructing the user to open the URL in a browser.
+ - Allow for OAuth 2.0 authorization by instructing the user to open the URL in a browser instead of opening the browser.
 
 
 ## [2.13.0] - 2020-06-25

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -415,7 +415,11 @@ class SpotifyOAuth(SpotifyAuthBase):
         redirect_info = urlparse(self.redirect_uri)
         redirect_host, redirect_port = get_host_port(redirect_info.netloc)
 
-        if open_browser and redirect_host in ("127.0.0.1", "localhost") and redirect_info.scheme == "http":
+        if (
+            open_browser
+            and redirect_host in ("127.0.0.1", "localhost")
+            and redirect_info.scheme == "http"
+        ):
             # Only start a local http server if a port is specified
             if redirect_port:
                 return self._get_auth_response_local_server(redirect_port)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -374,9 +374,17 @@ class SpotifyOAuth(SpotifyAuthBase):
         except webbrowser.Error:
             logger.error("Please navigate here: %s", auth_url)
 
-    def _get_auth_response_interactive(self):
-        self._open_auth_url()
-        response = SpotifyOAuth._get_user_input("Enter the URL you were redirected to: ")
+    def _get_auth_response_interactive(self, open_browser=True):
+        if open_browser:
+            self._open_auth_url()
+            prompt = "Enter the URL you were redirected to: "
+        else:
+            url = self.get_authorize_url()
+            prompt = (
+                "Go to the following URL: {}\n"
+                "Enter the URL you were redirected to: ".format(url)
+            )
+        response = SpotifyOAuth._get_user_input(prompt)
         state, code = SpotifyOAuth.parse_auth_response_url(response)
         if self.state is not None and self.state != state:
             raise SpotifyStateError(self.state, state)
@@ -397,7 +405,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         else:
             raise SpotifyOauthError("Server listening on localhost has not been accessed")
 
-    def get_auth_response(self):
+    def get_auth_response(self, open_browser=True):
         logger.info('User authentication requires interaction with your '
                     'web browser. Once you enter your credentials and '
                     'give authorization, you will be redirected to '
@@ -407,7 +415,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         redirect_info = urlparse(self.redirect_uri)
         redirect_host, redirect_port = get_host_port(redirect_info.netloc)
 
-        if redirect_host in ("127.0.0.1", "localhost") and redirect_info.scheme == "http":
+        if open_browser and redirect_host in ("127.0.0.1", "localhost") and redirect_info.scheme == "http":
             # Only start a local http server if a port is specified
             if redirect_port:
                 return self._get_auth_response_local_server(redirect_port)
@@ -421,7 +429,7 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         logger.info('Paste that url you were directed to in order to '
                     'complete the authorization')
-        return self._get_auth_response_interactive()
+        return self._get_auth_response_interactive(open_browser=open_browser)
 
     def get_authorization_code(self, response=None):
         if response:

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -431,8 +431,6 @@ class SpotifyOAuth(SpotifyAuthBase):
                                'the URL your browser is redirected to.',
                                redirect_host, redirect_host)
 
-        logger.info('Paste that url you were directed to in order to '
-                    'complete the authorization')
         return self._get_auth_response_interactive(open_browser=open_browser)
 
     def get_authorization_code(self, response=None):


### PR DESCRIPTION
This adds a new option `open_browser` in `get_auth_response` which, if False, will simply print the authorization URL and ask the user to visit it and paste the URL is has been redirected to  (existing interactive way to get the authorization code). This allows the setup of Spotipy on a remote machine (e.g. Raspberry Pi or VPS) in a fully headless way.

`open_browser` defaults to True for backward compatibility.