### PR TITLE
Add redirect_uri to the environment

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -5,6 +5,7 @@ Prerequisites
 
     export SPOTIPY_CLIENT_ID=client_id_here
     export SPOTIPY_CLIENT_SECRET=client_secret_here
+    export SPOTIPY_REDIRECT_URI='http://127.0.0.1:8080' // added to your [app settings](https://developer.spotify.com/dashboard/applications)
     // on Windows, use `SET` instead of `export`
 
 Run app.py


### PR DESCRIPTION
And specify that it should be the address that the App runs over. 

Would it also be useful for the example to include a cache_path, so that it "works" more immediately?

```
CACHE = ".cache-" + "test"
SCOPE = None
# user-top-read user-library-read playlist-read-public user-follow-read
auth_manager = spotipy.oauth2.SpotifyOAuth(credentials.SPOTIPY_CLIENT_ID, credentials.SPOTIPY_CLIENT_SECRET, credentials.SPOTIPY_REDIRECT_URI, scope=SCOPE, show_dialog=True, cache_path=CACHE)
```