### PR TITLE
Update Playlist Endpoints and Add Following Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `user_playlist_change_details` in favor of `playlist_change_details`
 - `user_playlist_unfollow` in favor of `current_user_unfollow_playlist`
-- `user_playlist_add_tracks` in favor of `playlist_add_tracks`
-- `user_playlist_replace_tracks` in favor of `playlist_replace_tracks`
-- `user_playlist_reorder_tracks` in favor of `playlist_reorder_tracks`
+- `user_playlist_add_tracks` in favor of `playlist_add_items`
+- `user_playlist_replace_tracks` in favor of `playlist_replace_items`
+- `user_playlist_reorder_tracks` in favor of `playlist_reorder_items`
 - `user_playlist_remove_all_occurrences_of_tracks` in favor of
- `playlist_remove_all_occurrences_of_tracks`
+ `playlist_remove_all_occurrences_of_items`
 - `user_playlist_remove_specific_occurrences_of_tracks` in favor of
- `playlist_remove_specific_occurrences_of_tracks`
+ `playlist_remove_specific_occurrences_of_items`
 - `user_playlist_follow_playlist` in favor of
  `current_user_follow_playlist`
 - `user_playlist_is_following` in favor of `playlist_is_following`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `user_playlist_follow_playlist` in favor of
  `current_user_follow_playlist`
 - `user_playlist_is_following` in favor of `playlist_is_following`
+- `playlist_tracks` in favor of `playlist_items`
 
 ## [2.13.0] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - Support to search multiple markets at once.
  - Support to search all available Spotify markets.
+ - Support to test whether the current user is following certain
+ users or artists
+ - Proper replacements for all deprecated playlist endpoints
+ (See https://developer.spotify.com/community/news/2018/06/12/changes-to-playlist-uris/ and below)
+
+### Deprecated
+
+- `user_playlist_change_details` in favor of `playlist_change_details`
+- `user_playlist_unfollow` in favor of `current_user_unfollow_playlist`
+- `user_playlist_add_tracks` in favor of `playlist_add_tracks`
+- `user_playlist_replace_tracks` in favor of `playlist_replace_tracks`
+- `user_playlist_reorder_tracks` in favor of `playlist_reorder_tracks`
+- `user_playlist_remove_all_occurrences_of_tracks` in favor of
+ `playlist_remove_all_occurrences_of_tracks`
+- `user_playlist_remove_specific_occurrences_of_tracks` in favor of
+ `playlist_remove_specific_occurrences_of_tracks`
+- `user_playlist_follow_playlist` in favor of
+ `current_user_follow_playlist`
+- `user_playlist_is_following` in favor of `playlist_is_following`
 
 ## [2.13.0] - 2020-06-25
 

--- a/examples/add_tracks_to_playlist.py
+++ b/examples/add_tracks_to_playlist.py
@@ -22,7 +22,7 @@ def main():
     args = get_args()
 
     sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-    sp.playlist_add_tracks(args.playlist, args.tids)
+    sp.playlist_add_items(args.playlist, args.tids)
 
 
 if __name__ == '__main__':

--- a/examples/add_tracks_to_playlist.py
+++ b/examples/add_tracks_to_playlist.py
@@ -22,8 +22,7 @@ def main():
     args = get_args()
 
     sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-    user_id = sp.me()['id']
-    sp.user_playlist_add_tracks(user_id, args.playlist, args.tids)
+    sp.playlist_add_tracks(args.playlist, args.tids)
 
 
 if __name__ == '__main__':

--- a/examples/change_playlist_details.py
+++ b/examples/change_playlist_details.py
@@ -35,8 +35,7 @@ def get_args():
 def main():
     args = get_args()
     sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-    sp.user_playlist_change_details(
-        args.username,
+    sp.playlist_change_details(
         args.playlist,
         name=args.name,
         public=args.public or args.private,

--- a/examples/playlist_all_non_local_tracks.py
+++ b/examples/playlist_all_non_local_tracks.py
@@ -10,20 +10,20 @@ sp = spotipy.Spotify(client_credentials_manager=SpotifyClientCredentials())
 
 # load the first 100 songs
 tracks = []
-result = sp.playlist_tracks(PlaylistExample)
+result = sp.playlist_items(PlaylistExample, additional_types=['track'])
 tracks.extend(result['items'])
 
 # if playlist is larger than 100 songs, continue loading it until end
 while result['next']:
-	result = sp.next(result)
-	tracks.extend(result['items'])
+    result = sp.next(result)
+    tracks.extend(result['items'])
 
 # remove all local songs
-i = 0 # just for counting how many tracks are local
+i = 0  # just for counting how many tracks are local
 for item in tracks:
-	if item['is_local']:
-		tracks.remove(item)
-		i += 1
+    if item['is_local']:
+        tracks.remove(item)
+        i += 1
 
 
 # print result

--- a/examples/playlist_tracks.py
+++ b/examples/playlist_tracks.py
@@ -8,9 +8,10 @@ pl_id = 'spotify:playlist:5RIbzhG2QqdkaP24iXLnZX'
 offset = 0
 
 while True:
-    response = sp.playlist_tracks(pl_id,
-                                  offset=offset,
-                                  fields='items.track.id,total')
+    response = sp.playlist_items(pl_id,
+                                 offset=offset,
+                                 fields='items.track.id,total',
+                                 additional_types=['track'])
     pprint(response['items'])
     offset = offset + len(response['items'])
     print(offset, "/", response['total'])

--- a/examples/remove_specific_tracks_from_playlist.py
+++ b/examples/remove_specific_tracks_from_playlist.py
@@ -22,8 +22,6 @@ else:
 scope = 'playlist-modify-public'
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-user_id = sp.me()['id']
-
-results = sp.user_playlist_remove_specific_occurrences_of_tracks(
-    user_id, playlist_id, track_ids)
+results = sp.playlist_remove_specific_occurrences_of_tracks(
+    playlist_id, track_ids)
 pprint.pprint(results)

--- a/examples/remove_specific_tracks_from_playlist.py
+++ b/examples/remove_specific_tracks_from_playlist.py
@@ -25,4 +25,3 @@ sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 results = sp.playlist_remove_specific_occurrences_of_items(
     playlist_id, track_ids)
 pprint.pprint(results)
-items

--- a/examples/remove_specific_tracks_from_playlist.py
+++ b/examples/remove_specific_tracks_from_playlist.py
@@ -22,6 +22,7 @@ else:
 scope = 'playlist-modify-public'
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-results = sp.playlist_remove_specific_occurrences_of_tracks(
+results = sp.playlist_remove_specific_occurrences_of_items(
     playlist_id, track_ids)
 pprint.pprint(results)
+items

--- a/examples/remove_tracks_from_playlist.py
+++ b/examples/remove_tracks_from_playlist.py
@@ -17,8 +17,6 @@ scope = 'playlist-modify-public'
 
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-user_id = sp.me()['id']
-
-results = sp.user_playlist_remove_all_occurrences_of_tracks(
-    user_id, playlist_id, track_ids)
+results = sp.playlist_remove_all_occurrences_of_tracks(
+    playlist_id, track_ids)
 pprint.pprint(results)

--- a/examples/remove_tracks_from_playlist.py
+++ b/examples/remove_tracks_from_playlist.py
@@ -17,6 +17,7 @@ scope = 'playlist-modify-public'
 
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-results = sp.playlist_remove_all_occurrences_of_tracks(
+results = sp.playlist_remove_all_occurrences_of_items(
     playlist_id, track_ids)
 pprint.pprint(results)
+items

--- a/examples/remove_tracks_from_playlist.py
+++ b/examples/remove_tracks_from_playlist.py
@@ -20,4 +20,3 @@ sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 results = sp.playlist_remove_all_occurrences_of_items(
     playlist_id, track_ids)
 pprint.pprint(results)
-items

--- a/examples/replace_tracks_in_playlist.py
+++ b/examples/replace_tracks_in_playlist.py
@@ -16,8 +16,7 @@ else:
 scope = 'playlist-modify-public'
 
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-user_id = sp.me()['id']
 
-results = sp.user_playlist_replace_tracks(user_id, playlist_id, track_ids)
+results = sp.playlist_replace_tracks(playlist_id, track_ids)
 pprint.pprint(results)
 

--- a/examples/replace_tracks_in_playlist.py
+++ b/examples/replace_tracks_in_playlist.py
@@ -19,5 +19,3 @@ sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
 results = sp.playlist_replace_items(playlist_id, track_ids)
 pprint.pprint(results)
-
-items

--- a/examples/replace_tracks_in_playlist.py
+++ b/examples/replace_tracks_in_playlist.py
@@ -17,6 +17,7 @@ scope = 'playlist-modify-public'
 
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
-results = sp.playlist_replace_tracks(playlist_id, track_ids)
+results = sp.playlist_replace_items(playlist_id, track_ids)
 pprint.pprint(results)
 
+items

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1167,7 +1167,7 @@ class Spotify(object):
             "me/following", type="artist", limit=limit, after=after
         )
 
-    def current_user_followed_artists_contains(self, ids=None):
+    def current_user_following_artists(self, ids=None):
         """ Check if the current user is following certain artists
 
             Returns list of booleans respective to ids
@@ -1181,6 +1181,22 @@ class Spotify(object):
         return self._get(
             "me/following/contains", ids=",".join(idlist), type="artist"
         )
+
+    def current_user_following_users(self, ids=None):
+        """ Check if the current user is following certain artists
+
+            Returns list of booleans respective to ids
+        
+            Parameters:
+                - ids - a list of user URIs, URLs or IDs
+        """
+        idlist = []
+        if ids is not None:
+            idlist = [self._get_id("user", i) for i in ids]
+        return self._get(
+            "me/following/contains", ids=",".join(idlist), type="user"
+        )
+
 
     def current_user_saved_tracks_delete(self, tracks=None):
         """ Remove one or more tracks from the current user's

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -715,6 +715,10 @@ class Spotify(object):
         collaborative=None,
         description=None,
     ):
+        warnings.warn(
+            "You should use `playlist_change_details(playlist_id, ...)` instead",
+            DeprecationWarning,
+        )
         """ Changes a playlist's name and/or public/private state
 
             Parameters:
@@ -746,6 +750,10 @@ class Spotify(object):
                 - user - the id of the user
                 - name - the name of the playlist
         """
+        warnings.warn(
+            "You should use `current_user_unfollow_playlist(playlist_id)` instead",
+            DeprecationWarning,
+        )
         return self._delete(
             "users/%s/playlists/%s/followers" % (user, playlist_id)
         )
@@ -753,6 +761,10 @@ class Spotify(object):
     def user_playlist_add_tracks(
         self, user, playlist_id, tracks, position=None
     ):
+        warnings.warn(
+            "You should use `playlist_add_tracks(playlist_id, tracks)` instead",
+            DeprecationWarning,
+        )
         """ Adds tracks to a playlist
 
             Parameters:
@@ -777,6 +789,10 @@ class Spotify(object):
                 - playlist_id - the id of the playlist
                 - tracks - the list of track ids to add to the playlist
         """
+        warnings.warn(
+            "You should use `playlist_replace_tracks(playlist_id, tracks)` instead",
+            DeprecationWarning,
+        )
         plid = self._get_id("playlist", playlist_id)
         ftracks = [self._get_uri("track", tid) for tid in tracks]
         payload = {"uris": ftracks}
@@ -805,6 +821,10 @@ class Spotify(object):
                                   inserted
                 - snapshot_id - optional playlist's snapshot ID
         """
+        warnings.warn(
+            "You should use `playlist_reorder_tracks(playlist_id, ...)` instead",
+            DeprecationWarning,
+        )
         plid = self._get_id("playlist", playlist_id)
         payload = {
             "range_start": range_start,
@@ -829,7 +849,11 @@ class Spotify(object):
                 - snapshot_id - optional id of the playlist snapshot
 
         """
-
+        warnings.warn(
+            "You should use `playlist_remove_all_occurrences_of_tracks"
+            "(playlist_id, tracks)` instead",
+            DeprecationWarning,
+        )
         plid = self._get_id("playlist", playlist_id)
         ftracks = [self._get_uri("track", tid) for tid in tracks]
         payload = {"tracks": [{"uri": track} for track in ftracks]}
@@ -854,7 +878,11 @@ class Spotify(object):
                         { "uri":"1301WleyT98MSxVHPZCA6M", "positions":[7] } ]
                 - snapshot_id - optional id of the playlist snapshot
         """
-
+        warnings.warn(
+            "You should use `playlist_remove_specific_occurrences_of_tracks"
+            "(playlist_id, tracks)` instead",
+            DeprecationWarning,
+        )
         plid = self._get_id("playlist", playlist_id)
         ftracks = []
         for tr in tracks:
@@ -880,6 +908,10 @@ class Spotify(object):
             - playlist_id - the id of the playlist
 
         """
+        warnings.warn(
+            "You should use `current_user_follow_playlist(playlist_id)` instead",
+            DeprecationWarning,
+        )
         return self._put(
             "users/{}/playlists/{}/followers".format(
                 playlist_owner_id, playlist_id
@@ -899,9 +931,199 @@ class Spotify(object):
                 if they follow the playlist. Maximum: 5 ids.
 
         """
+        warnings.warn(
+            "You should use `playlist_is_following(playlist_id, user_ids)` instead",
+            DeprecationWarning,
+        )
         endpoint = "users/{}/playlists/{}/followers/contains?ids={}"
         return self._get(
             endpoint.format(playlist_owner_id, playlist_id, ",".join(user_ids))
+        )
+
+    def playlist_change_details(
+        self,
+        playlist_id,
+        name=None,
+        public=None,
+        collaborative=None,
+        description=None,
+    ):
+        """ Changes a playlist's name and/or public/private state
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - name - optional name of the playlist
+                - public - optional is the playlist public
+                - collaborative - optional is the playlist collaborative
+                - description - optional description of the playlist
+        """
+
+        data = {}
+        if isinstance(name, six.string_types):
+            data["name"] = name
+        if isinstance(public, bool):
+            data["public"] = public
+        if isinstance(collaborative, bool):
+            data["collaborative"] = collaborative
+        if isinstance(description, six.string_types):
+            data["description"] = description
+        return self._put(
+            "playlists/%s" % (playlist_id), payload=data
+        )
+
+    def current_user_unfollow_playlist(self, playlist_id):
+        """ Unfollows (deletes) a playlist for the current authenticated
+            user
+
+            Parameters:
+                - name - the name of the playlist
+        """
+        return self._delete(
+            "playlists/%s/followers" % (playlist_id)
+        )
+
+    def playlist_add_tracks(
+        self, playlist_id, tracks, position=None
+    ):
+        """ Adds tracks to a playlist
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - tracks - a list of track URIs, URLs or IDs
+                - position - the position to add the tracks
+        """
+        plid = self._get_id("playlist", playlist_id)
+        ftracks = [self._get_uri("track", tid) for tid in tracks]
+        return self._post(
+            "playlists/%s/tracks" % (plid),
+            payload=ftracks,
+            position=position,
+        )
+
+    def playlist_replace_tracks(self, playlist_id, tracks):
+        """ Replace all tracks in a playlist
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - tracks - the list of track ids to add to the playlist
+        """
+        plid = self._get_id("playlist", playlist_id)
+        ftracks = [self._get_uri("track", tid) for tid in tracks]
+        payload = {"uris": ftracks}
+        return self._put(
+            "playlists/%s/tracks" % (plid), payload=payload
+        )
+
+    def playlist_reorder_tracks(
+        self,
+        playlist_id,
+        range_start,
+        insert_before,
+        range_length=1,
+        snapshot_id=None,
+    ):
+        """ Reorder tracks in a playlist
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - range_start - the position of the first track to be reordered
+                - range_length - optional the number of tracks to be reordered
+                                 (default: 1)
+                - insert_before - the position where the tracks should be
+                                  inserted
+                - snapshot_id - optional playlist's snapshot ID
+        """
+        plid = self._get_id("playlist", playlist_id)
+        payload = {
+            "range_start": range_start,
+            "range_length": range_length,
+            "insert_before": insert_before,
+        }
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
+        return self._put(
+            "playlists/%s/tracks" % (plid), payload=payload
+        )
+
+    def playlist_remove_all_occurrences_of_tracks(
+        self, playlist_id, tracks, snapshot_id=None
+    ):
+        """ Removes all occurrences of the given tracks from the given playlist
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - tracks - the list of track ids to remove from the playlist
+                - snapshot_id - optional id of the playlist snapshot
+
+        """
+
+        plid = self._get_id("playlist", playlist_id)
+        ftracks = [self._get_uri("track", tid) for tid in tracks]
+        payload = {"tracks": [{"uri": track} for track in ftracks]}
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
+        return self._delete(
+            "playlists/%s/tracks" % (plid), payload=payload
+        )
+
+    def playlist_remove_specific_occurrences_of_tracks(
+        self, playlist_id, tracks, snapshot_id=None
+    ):
+        """ Removes all occurrences of the given tracks from the given playlist
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - tracks - an array of objects containing Spotify URIs of the
+                    tracks to remove with their current positions in the
+                    playlist.  For example:
+                        [  { "uri":"4iV5W9uYEdYUVa79Axb7Rh", "positions":[2] },
+                        { "uri":"1301WleyT98MSxVHPZCA6M", "positions":[7] } ]
+                - snapshot_id - optional id of the playlist snapshot
+        """
+
+        plid = self._get_id("playlist", playlist_id)
+        ftracks = []
+        for tr in tracks:
+            ftracks.append(
+                {
+                    "uri": self._get_uri("track", tr["uri"]),
+                    "positions": tr["positions"],
+                }
+            )
+        payload = {"tracks": ftracks}
+        if snapshot_id:
+            payload["snapshot_id"] = snapshot_id
+        return self._delete(
+            "playlists/%s/tracks" % (plid), payload=payload
+        )
+
+    def current_user_follow_playlist(self, playlist_id):
+        """
+        Add the current authenticated user as a follower of a playlist.
+
+        Parameters:
+            - playlist_id - the id of the playlist
+
+        """
+        return self._put(
+            "playlists/{}/followers".format(playlist_id)
+        )
+
+    def playlist_is_following(
+        self, playlist_id, user_ids
+    ):
+        """
+        Check to see if the given users are following the given playlist
+
+        Parameters:
+            - playlist_id - the id of the playlist
+            - user_ids - the ids of the users that you want to check to see
+                if they follow the playlist. Maximum: 5 ids.
+
+        """
+        endpoint = "playlists/{}/followers/contains?ids={}"
+        return self._get(
+            endpoint.format(playlist_id, ",".join(user_ids))
         )
 
     def me(self):
@@ -943,6 +1165,21 @@ class Spotify(object):
         """
         return self._get(
             "me/following", type="artist", limit=limit, after=after
+        )
+
+    def current_user_followed_artists_contains(self, ids=None):
+        """ Check if the current user is following certain artists
+
+            Returns list of booleans respective to ids
+        
+            Parameters:
+                - ids - a list of artist URIs, URLs or IDs
+        """
+        idlist = []
+        if ids is not None:
+            idlist = [self._get_id("artist", i) for i in ids]
+        return self._get(
+            "me/following/contains", ids=",".join(idlist), type="artist"
         )
 
     def current_user_saved_tracks_delete(self, tracks=None):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -598,6 +598,34 @@ class Spotify(object):
                 - additional_types - list of item types to return.
                                      valid types are: track and episode
         """
+        warnings.warn(
+            "You should use `playlist_items(playlist_id, ...,"
+            "additional_types=('track',))` instead",
+            DeprecationWarning,
+        )
+        return self.playlist_items(playlist_id, fields, limit, offset,
+                                   market, additional_types)
+
+    def playlist_items(
+        self,
+        playlist_id,
+        fields=None,
+        limit=100,
+        offset=0,
+        market=None,
+        additional_types=("track", "episode")
+    ):
+        """ Get full details of the tracks and episodes of a playlist.
+
+            Parameters:
+                - playlist_id - the id of the playlist
+                - fields - which fields to return
+                - limit - the maximum number of tracks to return
+                - offset - the index of the first track to return
+                - market - an ISO 3166-1 alpha-2 country code.
+                - additional_types - list of item types to return.
+                                     valid types are: track and episode
+        """
         plid = self._get_id("playlist", playlist_id)
         return self._get(
             "playlists/%s/tracks" % (plid),

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1171,7 +1171,7 @@ class Spotify(object):
         """ Check if the current user is following certain artists
 
             Returns list of booleans respective to ids
-        
+
             Parameters:
                 - ids - a list of artist URIs, URLs or IDs
         """
@@ -1186,7 +1186,7 @@ class Spotify(object):
         """ Check if the current user is following certain artists
 
             Returns list of booleans respective to ids
-        
+
             Parameters:
                 - ids - a list of user URIs, URLs or IDs
         """
@@ -1196,7 +1196,6 @@ class Spotify(object):
         return self._get(
             "me/following/contains", ids=",".join(idlist), type="user"
         )
-
 
     def current_user_saved_tracks_delete(self, tracks=None):
         """ Remove one or more tracks from the current user's

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -112,17 +112,17 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         # add tracks to playlist
         self.spotify.playlist_add_items(
             self.new_playlist['id'], self.other_tracks)
-        playlist = self.spotify.playlist(self.new_playlist['id'])
-        self.assertEqual(playlist['tracks']['total'], 3)
-        self.assertEqual(len(playlist['tracks']['items']), 3)
+        playlist = self.spotify.playlist_items(self.new_playlist['id'])
+        self.assertEqual(playlist['total'], 3)
+        self.assertEqual(len(playlist['items']), 3)
 
         pl = self.spotify.playlist_items(self.new_playlist['id'], limit=2)
         self.assertEqual(len(pl["items"]), 2)
 
         self.spotify.playlist_remove_all_occurrences_of_items(
-            playlist['id'], self.other_tracks)
-        playlist = self.spotify.playlist(self.new_playlist['id'])
-        self.assertEqual(playlist["tracks"]["total"], 0)
+            self.new_playlist['id'], self.other_tracks)
+        playlist = self.spotify.playlist_items(self.new_playlist['id'])
+        self.assertEqual(playlist["total"], 0)
 
     def test_playlist_cover_image(self):
         # Upload random dog image

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -84,22 +84,22 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         self.assertTrue(len(follows) == 1, 'proper follows length')
         self.assertFalse(follows[0], 'is no longer following')
 
-    def test_playlist_replace_tracks(self):
+    def test_playlist_replace_items(self):
         # add tracks to playlist
-        self.spotify.playlist_add_tracks(
+        self.spotify.playlist_add_items(
             self.new_playlist['id'], self.four_tracks)
         playlist = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(playlist['tracks']['total'], 4)
         self.assertEqual(len(playlist['tracks']['items']), 4)
 
         # replace with 3 other tracks
-        self.spotify.playlist_replace_tracks(self.new_playlist['id'],
-                                             self.other_tracks)
+        self.spotify.playlist_replace_items(self.new_playlist['id'],
+                                            self.other_tracks)
         playlist = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(playlist['tracks']['total'], 3)
         self.assertEqual(len(playlist['tracks']['items']), 3)
 
-        self.spotify.playlist_remove_all_occurrences_of_tracks(
+        self.spotify.playlist_remove_all_occurrences_of_items(
             playlist['id'], self.other_tracks)
         playlist = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(playlist["tracks"]["total"], 0)
@@ -108,9 +108,9 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         pl = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(pl["tracks"]["total"], 0)
 
-    def test_playlist_add_tracks(self):
+    def test_playlist_add_items(self):
         # add tracks to playlist
-        self.spotify.playlist_add_tracks(
+        self.spotify.playlist_add_items(
             self.new_playlist['id'], self.other_tracks)
         playlist = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(playlist['tracks']['total'], 3)
@@ -119,7 +119,7 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         pl = self.spotify.playlist_tracks(self.new_playlist['id'], limit=2)
         self.assertEqual(len(pl["items"]), 2)
 
-        self.spotify.playlist_remove_all_occurrences_of_tracks(
+        self.spotify.playlist_remove_all_occurrences_of_items(
             playlist['id'], self.other_tracks)
         playlist = self.spotify.playlist(self.new_playlist['id'])
         self.assertEqual(playlist["tracks"]["total"], 0)

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -53,14 +53,14 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         self.assertTrue('items' in playlists)
         self.assertGreaterEqual(len(playlists['items']), 1)
 
-    def test_playlist_tracks(self):
+    def test_playlist_items(self):
         playlists = self.spotify.user_playlists(self.username, limit=5)
         self.assertTrue('items' in playlists)
         for playlist in playlists['items']:
             if playlist['uri'] != self.new_playlist_uri:
                 continue
             pid = playlist['id']
-            results = self.spotify.playlist_tracks(pid)
+            results = self.spotify.playlist_items(pid)
             self.assertEqual(len(results['items']), 0)
 
     def test_current_user_playlists(self):
@@ -116,7 +116,7 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
         self.assertEqual(playlist['tracks']['total'], 3)
         self.assertEqual(len(playlist['tracks']['items']), 3)
 
-        pl = self.spotify.playlist_tracks(self.new_playlist['id'], limit=2)
+        pl = self.spotify.playlist_items(self.new_playlist['id'], limit=2)
         self.assertEqual(len(pl["items"]), 2)
 
         self.spotify.playlist_remove_all_occurrences_of_items(


### PR DESCRIPTION
Add current_user_following_artists and current_user_following_users

Deprecate user_playlist_* in favor of the following replacements:
* user_playlist_change_details -> playlist_change_details
* user_playlist_unfollow -> current_user_unfollow_playlist
* user_playlist_add_tracks -> playlist_add_tracks
* user_playlist_replace_tracks -> playlist_replace_tracks
* user_playlist_reorder_tracks -> playlist_reorder_tracks
* user_playlist_remove_all_occurrences_of_tracks -> playlist_remove_all_occurrences_of_tracks
* user_playlist_remove_specific_occurrences_of_tracks -> playlist_remove_specific_occurrences_of_tracks
* user_playlist_follow_playlist -> current_user_follow_playlist
* user_playlist_is_following -> playlist_is_following