### PR TITLE
Adding Initial PKCE Auth Flow Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Proper replacements for all deprecated playlist endpoints
  (See https://developer.spotify.com/community/news/2018/06/12/changes-to-playlist-uris/ and below)
 - Allow for OAuth 2.0 authorization by instructing the user to open the URL in a browser instead of opening the browser.
+- Support for the PKCE Auth Flow
 
 ### Deprecated
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -7,6 +7,7 @@ __all__ = [
     "SpotifyOauthError",
     "SpotifyStateError",
     "SpotifyImplicitGrant",
+    "SpotifyPKCE"
 ]
 
 import base64

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -578,8 +578,9 @@ class SpotifyPKCE(SpotifyAuthBase):
         self.requests_timeout = requests_timeout
         self._code_challenge_method = "S256" # Spotify requires SHA256
         self.code_verifier = self._get_code_verifier()
+        print(self.code_verifier + str(len(self.code_verifier)))
         self.code_challenge = self._get_code_challenge(self.code_verifier)
-        self.authorization_code = self.get_authorization_code()
+        self.authorization_code = None
 
     def _normalize_scope(self, scope):
         if scope:
@@ -589,8 +590,9 @@ class SpotifyPKCE(SpotifyAuthBase):
             return None
 
     def _get_code_verifier(self):
-        import secrets
-        return secrets.token_urlsafe(80) # Spotify wants between 43 to 128 characters.
+        import secrets, random
+        length = random.randint(33, 96)      # Range (33,96) is used to select between 44-128 base64 characters for the next operation
+        return secrets.token_urlsafe(length) # The seeded length generates between a 44 and 128 base64 characters encoded string
 
     def _get_code_challenge(self, code_verifier):
         import hashlib
@@ -780,7 +782,7 @@ class SpotifyPKCE(SpotifyAuthBase):
         payload = {
             "client_id": self.client_id,
             "grant_type": "authorization_code",
-            "code": self.authorization_code,
+            "code": self.get_authorization_code(),
             "redirect_uri": self.redirect_uri,
             "code_verifier": self.code_verifier
         }

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -838,7 +838,7 @@ class SpotifyPKCE(SpotifyAuthBase):
         if response.status_code != 200:
             error_payload = response.json()
             raise SpotifyOauthError('error: {0}, error_descr: {1}'.format(error_payload['error'],
-                                    error_payload['error_description']),
+                                                                          error_payload['error_description']),
                                     error=error_payload['error'],
                                     error_description=error_payload['error_description'])
         token_info = response.json()

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -578,7 +578,6 @@ class SpotifyPKCE(SpotifyAuthBase):
         self.requests_timeout = requests_timeout
         self._code_challenge_method = "S256" # Spotify requires SHA256
         self.code_verifier = self._get_code_verifier()
-        print(self.code_verifier + str(len(self.code_verifier)))
         self.code_challenge = self._get_code_challenge(self.code_verifier)
         self.authorization_code = None
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -590,11 +590,17 @@ class SpotifyPKCE(SpotifyAuthBase):
             return None
 
     def _get_code_verifier(self):
+        ''' Spotify PCKE code verifier - See step 1 of the reference guide below
+        Reference: https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
+        '''
         import secrets, random
         length = random.randint(33, 96)      # Range (33,96) is used to select between 44-128 base64 characters for the next operation
         return secrets.token_urlsafe(length) # The seeded length generates between a 44 and 128 base64 characters encoded string
 
     def _get_code_challenge(self, code_verifier):
+        ''' Spotify PCKE code challenge - See step 1 of the reference guide below
+        Reference: https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
+        '''
         import hashlib
         import base64
         code_challenge_digest = hashlib.sha256(code_verifier.encode('utf-8')).digest()

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -623,7 +623,8 @@ class SpotifyPKCE(SpotifyAuthBase):
         '''
         import secrets
         import random
-        # Range (33,96) is used to select between 44-128 base64 characters for the next operation
+        # Range (33,96) is used to select between 44-128 base64 characters for the
+        # next operation. The range looks weird because base64 is 6 bytes
         length = random.randint(33, 96)
         # The seeded length generates between a 44 and 128 base64 characters encoded string
         return secrets.token_urlsafe(length)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -621,13 +621,21 @@ class SpotifyPKCE(SpotifyAuthBase):
         Reference:
         https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
         '''
-        import secrets
-        import random
         # Range (33,96) is used to select between 44-128 base64 characters for the
         # next operation. The range looks weird because base64 is 6 bytes
+        import random
         length = random.randint(33, 96)
+
         # The seeded length generates between a 44 and 128 base64 characters encoded string
-        return secrets.token_urlsafe(length)
+        try:
+            import secrets
+            verifier = secrets.token_urlsafe(length)
+        except ImportError as e:    # For python 3.5 support
+            import os
+            import base64
+            rand_bytes = os.urandom(length)
+            verifier = base64.urlsafe_b64encode(rand_bytes).decode('utf-8').replace('=','')
+        return verifier
 
     def _get_code_challenge(self):
         ''' Spotify PCKE code challenge - See step 1 of the reference guide below

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -803,24 +803,14 @@ class SpotifyPKCE(SpotifyAuthBase):
         self.code_verifier = self._get_code_verifier()
         self.code_challenge = self._get_code_challenge()
 
-    def get_access_token(self, as_dict=False, check_cache=True):
+    def get_access_token(self, check_cache=True):
         """ Gets the access token for the app given the code
 
             Parameters:
-                - auth_code - the response from get_authorization_code()
-                - as_dict - a boolean indicating if returning the access token
-                            as a token_info dictionary, otherwise it will be returned
-                            as a string.
+                - check_cache - check for locally stored token before request
+                                a new token if True
         """
-        if as_dict:
-            warnings.warn(
-                "You're using 'as_dict = True'."
-                "get_access_token will return the token string directly in future "
-                "versions. Please adjust your code accordingly, or use "
-                "get_cached_token instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+
         if check_cache:
             token_info = self.get_cached_token()
             if token_info is not None:
@@ -828,7 +818,7 @@ class SpotifyPKCE(SpotifyAuthBase):
                     token_info = self.refresh_access_token(
                         token_info["refresh_token"]
                     )
-                return token_info if as_dict else token_info["access_token"]
+                return token_info["access_token"]
 
         if self.code_verifier is None or self.code_challenge is None:
             self.get_pkce_handshake_parameters()
@@ -862,7 +852,7 @@ class SpotifyPKCE(SpotifyAuthBase):
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
         self._save_token_info(token_info)
-        return token_info if as_dict else token_info["access_token"]
+        return token_info["access_token"]
 
     def refresh_access_token(self, refresh_token):
         payload = {

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -630,11 +630,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         try:
             import secrets
             verifier = secrets.token_urlsafe(length)
-        except ImportError as e:    # For python 3.5 support
+        except ImportError:    # For python 3.5 support
             import os
             import base64
             rand_bytes = os.urandom(length)
-            verifier = base64.urlsafe_b64encode(rand_bytes).decode('utf-8').replace('=','')
+            verifier = base64.urlsafe_b64encode(rand_bytes).decode('utf-8').replace('=', '')
         return verifier
 
     def _get_code_challenge(self):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -846,7 +846,9 @@ class SpotifyPKCE(SpotifyAuthBase):
         if response.status_code != 200:
             error_payload = response.json()
             raise SpotifyOauthError('error: {0}, error_descr: {1}'.format(error_payload['error'],
-                                                                          error_payload['error_description']),
+                                                                          error_payload[
+                                                                              'error_description'
+                                                                              ]),
                                     error=error_payload['error'],
                                     error_description=error_payload['error_description'])
         token_info = response.json()

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -551,6 +551,315 @@ class SpotifyOAuth(SpotifyAuthBase):
         token_info["scope"] = self.scope
         return token_info
 
+class SpotifyPKCE(SpotifyAuthBase):
+
+    OAUTH_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
+    OAUTH_TOKEN_URL = "https://accounts.spotify.com/api/token"
+
+    def __init__(self, 
+                 client_id=None, 
+                 redirect_uri=None, 
+                 code_challenge=None, 
+                 state=None, 
+                 scope=None,
+                 requests_session=True,
+                 cache_path=None,
+                 username=None,
+                 proxies=None,
+                 requests_timeout=None,):
+        super(SpotifyPKCE, self).__init__(requests_session)
+        self.client_id = client_id
+        self.redirect_uri = redirect_uri
+        self._code_challenge_method = "S256" # Spotify requires SHA256
+        self.code_verifier = self._get_code_verifier()
+        self.code_challenge = self._get_code_challenge(self.code_verifier)
+        self.authorization_code = None
+        self.state = state
+        self.scope = self._normalize_scope(scope)
+        self.cache_path = cache_path
+        self.username = username        # Only used for naming the cache of the access token
+        self.proxies = proxies
+        self.requests_timeout = requests_timeout
+
+    def _normalize_scope(self, scope):
+        if scope:
+            scopes = sorted(scope.split())
+            return " ".join(scopes)
+        else:
+            return None
+
+    def _get_code_verifier(self):
+        import secrets
+        return secrets.token_urlsafe(80) # Spotify wants between 43 to 128 characters.
+
+    def _get_code_challenge(self, code_verifier):
+        import hashlib
+        import base64
+        code_challenge_digest = hashlib.sha256(code_verifier.encode('utf-8')).digest()
+        code_challenge = base64.urlsafe_b64encode(code_challenge_digest).decode('utf-8')
+        return code_challenge.replace('=', '')
+
+    def get_authorize_url(self, state=None):
+        """ Gets the URL to use to authorize this app """
+        payload = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": self.redirect_uri,
+            "code_challenge_method": self._code_challenge_method,
+            "code_challenge": self.code_challenge
+        }
+        if self.scope:
+            payload["scope"] = self.scope
+        if state is None:
+            state = self.state
+        if state is not None:
+            payload["state"] = state
+        urlparams = urllibparse.urlencode(payload)
+        return "%s?%s" % (self.OAUTH_AUTHORIZE_URL, urlparams)
+
+    def _open_auth_url(self, state=None):
+        auth_url = self.get_authorize_url(state)
+        try:
+            webbrowser.open(auth_url)
+            logger.info("Opened %s in your browser", auth_url)
+        except webbrowser.Error:
+            logger.error("Please navigate here: %s", auth_url)
+
+    def _get_auth_response(self, open_browser=True):
+        logger.info('User authentication requires interaction with your '
+                    'web browser. Once you enter your credentials and '
+                    'give authorization, you will be redirected to '
+                    'a url.  Paste that url you were directed to to '
+                    'complete the authorization.')
+
+        redirect_info = urlparse(self.redirect_uri)
+        redirect_host, redirect_port = get_host_port(redirect_info.netloc)
+
+        if (
+            open_browser
+            and redirect_host in ("127.0.0.1", "localhost")
+            and redirect_info.scheme == "http"
+        ):
+            # Only start a local http server if a port is specified
+            if redirect_port:
+                return self._get_auth_response_local_server(redirect_port)
+            else:
+                logger.warning('Using `%s` as redirect URI without a port. '
+                               'Specify a port (e.g. `%s:8080`) to allow '
+                               'automatic retrieval of authentication code '
+                               'instead of having to copy and paste '
+                               'the URL your browser is redirected to.',
+                               redirect_host, redirect_host)
+        return self._get_auth_response_interactive(open_browser=open_browser)
+
+    def _get_auth_response_local_server(self, redirect_port):
+        server = start_local_http_server(redirect_port)
+        self._open_auth_url()
+        server.handle_request()
+
+        if self.state is not None and server.state != self.state:
+            raise SpotifyStateError(self.state, server.state)
+
+        if server.auth_code is not None:
+            self.authorization_code = server.auth_code
+            return server.auth_code
+        elif server.error is not None:
+            raise SpotifyOauthError("Received error from OAuth server: {}".format(server.error))
+        else:
+            raise SpotifyOauthError("Server listening on localhost has not been accessed")
+
+    def _get_auth_response_interactive(self, open_browser=True):
+        if open_browser:
+            self._open_auth_url()
+            prompt = "Enter the URL you were redirected to: "
+        else:
+            url = self.get_authorize_url()
+            prompt = (
+                "Go to the following URL: {}\n"
+                "Enter the URL you were redirected to: ".format(url)
+            )
+        response = SpotifyOAuth._get_user_input(prompt)
+        state, code = SpotifyOAuth.parse_auth_response_url(response)
+        if self.state is not None and self.state != state:
+            raise SpotifyStateError(self.state, state)
+        self.authorization_code = code
+        return code
+
+    def get_authorization_code(self, response=None):
+        if response:
+            return self.parse_response_code(response)
+        return self._get_auth_response()
+
+    def get_cached_token(self):
+        """ Gets a cached auth token
+        """
+        token_info = None
+
+        if not self.cache_path and self.username:
+            self.cache_path = ".cache-" + str(self.username)
+        elif not self.cache_path and not self.username:
+            raise SpotifyOauthError(
+                "You must either set a cache_path or a username."
+            )
+
+        if self.cache_path:
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
+
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+                ):
+                    return None
+
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+
+            except IOError:
+                pass
+        return token_info
+
+    def _is_scope_subset(self, needle_scope, haystack_scope):
+        needle_scope = set(needle_scope.split()) if needle_scope else set()
+        haystack_scope = (
+            set(haystack_scope.split()) if haystack_scope else set()
+        )
+        return needle_scope <= haystack_scope
+
+    def is_token_expired(self, token_info):
+        return is_token_expired(token_info)
+
+    def _save_token_info(self, token_info):
+        if self.cache_path:
+            try:
+                f = open(self.cache_path, "w")
+                f.write(json.dumps(token_info))
+                f.close()
+            except IOError:
+                logger.warning('Couldn\'t write token to cache at: %s',
+                               self.cache_path)
+
+    def _add_custom_values_to_token_info(self, token_info):
+        """
+        Store some values that aren't directly provided by a Web API
+        response.
+        """
+        token_info["expires_at"] = int(time.time()) + token_info["expires_in"]
+        return token_info
+
+    def get_access_token(self, auth_code=None, as_dict=False, check_cache=True):
+        """ Gets the access token for the app given the code
+
+            Parameters:
+                - auth_code - the response from get_authorization_code()
+                - as_dict - a boolean indicating if returning the access token
+                            as a token_info dictionary, otherwise it will be returned
+                            as a string.
+        """
+        if as_dict:
+            warnings.warn(
+                "You're using 'as_dict = True'."
+                "get_access_token will return the token string directly in future "
+                "versions. Please adjust your code accordingly, or use "
+                "get_cached_token instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if check_cache:
+            token_info = self.get_cached_token()
+            if token_info is not None:
+                if is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+                return token_info if as_dict else token_info["access_token"]
+
+        payload = {
+            "client_id": self.client_id,
+            "grant_type": "authorization_code",
+            "code": auth_code if auth_code is not None else self.authorization_code,
+            "redirect_uri": self.redirect_uri,
+            "code_verifier": self.code_verifier
+        }
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        response = self._session.post(
+            self.OAUTH_TOKEN_URL,
+            data=payload,
+            headers=headers,
+            verify=True,
+            proxies=self.proxies,
+            timeout=self.requests_timeout,
+        )
+        if response.status_code != 200:
+            error_payload = response.json()
+            raise SpotifyOauthError('error: {0}, error_description: {1}'.format(error_payload['error'], 
+                                                                                error_payload['error_description']),
+                                    error=error_payload['error'],
+                                    error_description=error_payload['error_description'])
+        token_info = response.json()
+        token_info = self._add_custom_values_to_token_info(token_info)
+        self._save_token_info(token_info)
+        return token_info if as_dict else token_info["access_token"]
+
+    def refresh_access_token(self, refresh_token):
+        payload = {
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+        }
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        response = self._session.post(
+            self.OAUTH_TOKEN_URL,
+            data=payload,
+            headers=headers,
+            proxies=self.proxies,
+            timeout=self.requests_timeout,
+        )
+
+        try:
+            response.raise_for_status()
+        except BaseException:
+            logger.error('Couldn\'t refresh token. Response Status Code: %s '
+                         'Reason: %s', response.status_code, response.reason)
+
+            message = "Couldn't refresh token: code:%d reason:%s" % (
+                response.status_code,
+                response.reason,
+            )
+            raise SpotifyException(response.status_code,
+                                   -1,
+                                   message,
+                                   headers)
+
+        token_info = response.json()
+        token_info = self._add_custom_values_to_token_info(token_info)
+        if "refresh_token" not in token_info:
+            token_info["refresh_token"] = refresh_token
+        self._save_token_info(token_info)
+        return token_info
+
+    def parse_response_code(self, url):
+        """ Parse the response code in the given response url
+
+            Parameters:
+                - url - the response url
+        """
+        _, code = SpotifyOAuth.parse_auth_response_url(url)
+        if code is None:
+            return url
+        else:
+            return code
+    
+
 
 class SpotifyImplicitGrant(SpotifyAuthBase):
     """ Implements Implicit Grant Flow for client apps
@@ -817,6 +1126,10 @@ window.close()
 <body>
 <h1>Authentication status: {}</h1>
 This window can be closed.
+<script>
+window.close()
+</script>
+<button class="closeButton" style="cursor: pointer" onclick="window.close();">Close Window</button>
 </body>
 </html>""".format(status))
 

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -5,7 +5,8 @@ from spotipy import (
     prompt_for_user_token,
     Spotify,
     SpotifyException,
-    SpotifyImplicitGrant
+    SpotifyImplicitGrant,
+    SpotifyPKCE
 )
 import unittest
 import requests
@@ -402,6 +403,38 @@ class SpotipyImplicitGrantTests(unittest.TestCase):
         )
         auth_manager = SpotifyImplicitGrant(scope=scope,
                                             cache_path=".cache-implicittest")
+        cls.spotify = Spotify(auth_manager=auth_manager)
+
+    def test_user_follows_and_unfollows_artist(self):
+        # Initially follows 1 artist
+        current_user_followed_artists = self.spotify.current_user_followed_artists()[
+            'artists']['total']
+
+        # Follow 2 more artists
+        artists = ["6DPYiyq5kWVQS4RGwxzPC7", "0NbfKEOTQCcwd6o7wSDOHI"]
+        self.spotify.user_follow_artists(artists)
+        res = self.spotify.current_user_followed_artists()
+        self.assertEqual(res['artists']['total'], current_user_followed_artists + len(artists))
+
+        # Unfollow these 2 artists
+        self.spotify.user_unfollow_artists(artists)
+        res = self.spotify.current_user_followed_artists()
+        self.assertEqual(res['artists']['total'], current_user_followed_artists)
+
+    def test_current_user(self):
+        c_user = self.spotify.current_user()
+        user = self.spotify.user(c_user['id'])
+        self.assertEqual(c_user['display_name'], user['display_name'])
+
+class SpotifyPKCETests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        scope = (
+            'user-follow-read '
+            'user-follow-modify '
+        )
+        auth_manager = SpotifyPKCE(scope=scope, cache_path=".cache-implicittest")
         cls.spotify = Spotify(auth_manager=auth_manager)
 
     def test_user_follows_and_unfollows_artist(self):

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -426,6 +426,7 @@ class SpotipyImplicitGrantTests(unittest.TestCase):
         user = self.spotify.user(c_user['id'])
         self.assertEqual(c_user['display_name'], user['display_name'])
 
+
 class SpotifyPKCETests(unittest.TestCase):
 
     @classmethod

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -45,6 +45,7 @@ def _make_oauth(*args, **kwargs):
 def _make_implicitgrantauth(*args, **kwargs):
     return SpotifyImplicitGrant("CLID", "REDIR", "STATE", *args, **kwargs)
 
+
 def _make_pkceauth(*args, **kwargs):
     return SpotifyPKCE("CLID", "REDIR", "STATE", *args, **kwargs)
 
@@ -337,6 +338,7 @@ class TestSpotifyImplicitGrant(unittest.TestCase):
         parsed_qs = urllibparse.parse_qs(parsed_url.query)
         self.assertTrue(parsed_qs['show_dialog'])
 
+
 class SpotifyPKCECacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyPKCE,
@@ -357,7 +359,6 @@ class SpotifyPKCECacheTest(unittest.TestCase):
         opener.assert_called_with(path)
         self.assertIsNotNone(cached_tok)
         self.assertEqual(refresh_access_token.call_count, 0)
-
 
     @patch.multiple(SpotifyPKCE,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
@@ -415,6 +416,7 @@ class SpotifyPKCECacheTest(unittest.TestCase):
         opener.assert_called_with(path, 'w')
         self.assertTrue(fi.write.called)
 
+
 class TestSpotifyPKCE(unittest.TestCase):
 
     def test_generate_code_verifier_for_pkce(self):
@@ -432,7 +434,12 @@ class TestSpotifyPKCE(unittest.TestCase):
         import base64
         auth = SpotifyPKCE()
         auth.get_pkce_handshake_parameters()
-        self.assertEqual(auth.code_challenge, base64.urlsafe_b64encode(hashlib.sha256(auth.code_verifier.encode('utf-8')).digest()).decode('utf-8').replace('=',''))
+        self.assertEqual(auth.code_challenge,
+                         base64.urlsafe_b64encode(
+                                hashlib.sha256(auth.code_verifier.encode('utf-8'))
+                                .digest())
+                         .decode('utf-8')
+                         .replace('=', ''))
 
     def test_get_authorize_url_doesnt_pass_state_by_default(self):
         auth = SpotifyPKCE("CLID", "REDIR")

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -5,10 +5,9 @@ import unittest
 
 import six.moves.urllib.parse as urllibparse
 
-from spotipy import SpotifyOAuth, SpotifyImplicitGrant
+from spotipy import SpotifyOAuth, SpotifyImplicitGrant, SpotifyPKCE
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 from spotipy.oauth2 import SpotifyStateError
-from spotipy.oauth2 import SpotifyPKCE
 
 try:
     import unittest.mock as mock

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -417,18 +417,21 @@ class SpotifyPKCECacheTest(unittest.TestCase):
 
 class TestSpotifyPKCE(unittest.TestCase):
 
-    def test_code_verifier_generates_during_construction(self):
+    def test_generate_code_verifier_for_pkce(self):
         auth = SpotifyPKCE()
+        auth.get_pkce_handshake_parameters()
         self.assertTrue(auth.code_verifier)
 
-    def test_code_challenge_generates_during_construction(self):
+    def test_generate_code_challenge_for_pkce(self):
         auth = SpotifyPKCE()
+        auth.get_pkce_handshake_parameters()
         self.assertTrue(auth.code_challenge)
 
     def test_code_verifier_and_code_challenge_are_correct(self):
         import hashlib
         import base64
         auth = SpotifyPKCE()
+        auth.get_pkce_handshake_parameters()
         self.assertEqual(auth.code_challenge, base64.urlsafe_b64encode(hashlib.sha256(auth.code_verifier.encode('utf-8')).digest()).decode('utf-8').replace('=',''))
 
     def test_get_authorize_url_doesnt_pass_state_by_default(self):
@@ -452,7 +455,7 @@ class TestSpotifyPKCE(unittest.TestCase):
 
     def test_get_authorize_url_passes_state_from_func_call(self):
         state = "STATE"
-        auth = _make_pkceauth()
+        auth = SpotifyPKCE("CLID", "REDIR")
 
         url = auth.get_authorize_url(state=state)
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -420,19 +420,19 @@ class SpotifyPKCECacheTest(unittest.TestCase):
 class TestSpotifyPKCE(unittest.TestCase):
 
     def test_generate_code_verifier_for_pkce(self):
-        auth = SpotifyPKCE()
+        auth = SpotifyPKCE("CLID", "REDIR")
         auth.get_pkce_handshake_parameters()
         self.assertTrue(auth.code_verifier)
 
     def test_generate_code_challenge_for_pkce(self):
-        auth = SpotifyPKCE()
+        auth = SpotifyPKCE("CLID", "REDIR")
         auth.get_pkce_handshake_parameters()
         self.assertTrue(auth.code_challenge)
 
     def test_code_verifier_and_code_challenge_are_correct(self):
         import hashlib
         import base64
-        auth = SpotifyPKCE()
+        auth = SpotifyPKCE("CLID", "REDIR")
         auth.get_pkce_handshake_parameters()
         self.assertEqual(auth.code_challenge,
                          base64.urlsafe_b64encode(


### PR DESCRIPTION
Adds functionality for the PKCE Authorization Flow. This is now the preferred method for developers to integrate desktops and mobile applications with the Spotify API.

The benefits include:
1. Being able to distribute applications without revealing the apps Client Secret
2. Not needing users to sign up for a developer account
3. Moves away from the deprecated Implicit Grant Auth Flow 

Requested in #538 - Sorry if I jumped the gun adding this functionality without commenting on the enhancement request/issue. I needed this functionality for an app I'm working on and saw the recent enhancement request for so decided to work on it.