### PR TITLE
Give a reason for player errors in SpotifyException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Proper replacements for all deprecated playlist endpoints
  (See https://developer.spotify.com/community/news/2018/06/12/changes-to-playlist-uris/ and below)
 - Allow for OAuth 2.0 authorization by instructing the user to open the URL in a browser instead of opening the browser.
+- Reason for 403 error in SpotifyException
 
 ### Deprecated
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -240,7 +240,6 @@ class Spotify(object):
                 msg = response.json()["error"]["message"]
             except (ValueError, KeyError):
                 msg = "error"
-            
             try:
                 reason = response.json()["error"]["reason"]
             except (ValueError, KeyError):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -240,6 +240,11 @@ class Spotify(object):
                 msg = response.json()["error"]["message"]
             except (ValueError, KeyError):
                 msg = "error"
+            
+            try:
+                reason = response.json()["error"]["reason"]
+            except (ValueError, KeyError):
+                reason = None
 
             logger.error('HTTP Error for %s to %s returned %s due to %s',
                          method, url, response.status_code, msg)
@@ -248,6 +253,7 @@ class Spotify(object):
                 response.status_code,
                 -1,
                 "%s:\n %s" % (response.url, msg),
+                reason=reason,
                 headers=response.headers,
             )
         except requests.exceptions.RetryError:

--- a/spotipy/exceptions.py
+++ b/spotipy/exceptions.py
@@ -1,9 +1,10 @@
 class SpotifyException(Exception):
 
-    def __init__(self, http_status, code, msg, headers=None):
+    def __init__(self, http_status, code, msg, reason=None, headers=None):
         self.http_status = http_status
         self.code = code
         self.msg = msg
+        self.reason = reason
         # `headers` is used to support `Retry-After` in the event of a
         # 429 status code.
         if headers is None:
@@ -11,5 +12,5 @@ class SpotifyException(Exception):
         self.headers = headers
 
     def __str__(self):
-        return 'http status: {0}, code:{1} - {2}'.format(
-            self.http_status, self.code, self.msg)
+        return 'http status: {0}, code:{1} - {2}, reason: {3}'.format(
+            self.http_status, self.code, self.msg, self.reason)


### PR DESCRIPTION
I added a reason for player errors returned by Spotify. The list of reasons can be viewed here: [list](https://developer.spotify.com/documentation/web-api/reference/object-model/#player-error-reasons). This change to SpotifyException will speed up the development process by giving more specific error descriptions to developers.

An example of how this could be used:
https://pastebin.com/hLMtjMBj