### PR TITLE
Advertise preferred language to Spotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  (See https://developer.spotify.com/community/news/2018/06/12/changes-to-playlist-uris/ and below)
 - Allow for OAuth 2.0 authorization by instructing the user to open the URL in a browser instead of opening the browser.
 - Support for the PKCE Auth Flow
+- Support to advertise different language to Spotify
 
 ### Deprecated
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -109,6 +109,7 @@ class Spotify(object):
         retries=max_retries,
         status_retries=max_retries,
         backoff_factor=0.3,
+        language=None,
     ):
         """
         Creates a Spotify API client.
@@ -141,6 +142,9 @@ class Spotify(object):
         :param backoff_factor:
             A backoff factor to apply between attempts after the second try
             See urllib3 https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html
+        :param language:
+            The language parameter advertises what language the user prefers to see.
+            See ISO-639 language code: https://www.loc.gov/standards/iso639-2/php/code_list.php
         """
         self.prefix = "https://api.spotify.com/v1/"
         self._auth = auth
@@ -153,6 +157,7 @@ class Spotify(object):
         self.backoff_factor = backoff_factor
         self.retries = retries
         self.status_retries = status_retries
+        self.language = language
 
         if isinstance(requests_session, requests.Session):
             self._session = requests_session
@@ -223,6 +228,9 @@ class Spotify(object):
             headers["Content-Type"] = "application/json"
             if payload:
                 args["data"] = json.dumps(payload)
+
+        if self.language is not None:
+            headers["Accept-Language"] = self.language
 
         logger.debug('Sending %s to %s with Headers: %s and Body: %r ',
                      method, url, headers, args.get('data'))


### PR DESCRIPTION
Some artist or track provide different translation for different language
usage. This requires send http request with Accept-Language in header.
Create this option for people who wants to see proper translation.

The result showed in the following:
![image](https://user-images.githubusercontent.com/495918/88076784-10cef200-cbad-11ea-8e7e-ec5c9ea5149c.png)
