### PR TITLE
Added the parameter collaborative to user_playlist_create and "collaborative" key into data

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -754,9 +754,9 @@ class Spotify(object):
                 - description - the description of the playlist
         """
         data = {
-            "name": name, 
-            "public": public, 
-            "collaborative": collaborative, 
+            "name": name,
+            "public": public,
+            "collaborative": collaborative,
             "description": description
         }
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -753,7 +753,12 @@ class Spotify(object):
                 - collaborative - is the created playlist collaborative
                 - description - the description of the playlist
         """
-        data = {"name": name, "public": public, "collaborative": collaborative, "description": description}
+        data = {
+            "name": name, 
+            "public": public, 
+            "collaborative": collaborative, 
+            "description": description
+        }
 
         return self._post("users/%s/playlists" % (user,), payload=data)
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -743,16 +743,17 @@ class Spotify(object):
             "users/%s/playlists" % user, limit=limit, offset=offset
         )
 
-    def user_playlist_create(self, user, name, public=True, description=""):
+    def user_playlist_create(self, user, name, public=True, collaborative=False, description=""):
         """ Creates a playlist for a user
 
             Parameters:
                 - user - the id of the user
                 - name - the name of the playlist
                 - public - is the created playlist public
+                - collaborative - is the created playlist collaborative
                 - description - the description of the playlist
         """
-        data = {"name": name, "public": public, "description": description}
+        data = {"name": name, "public": public, "collaborative": collaborative, "description": description}
 
         return self._post("users/%s/playlists" % (user,), payload=data)
 


### PR DESCRIPTION
I saw that in [Create a playlist Spotify](https://developer.spotify.com/documentation/web-api/reference/playlists/create-playlist/), there was a parameter for collaborative, but the user_playlist_create() does not have collaborative as a parameter. 


I placed the collaborative key behind description because that is the order in the link.
