### PR TITLE
Fix JSONDecodeError on reading cache if you somehow have empty cache

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -286,7 +286,6 @@ class SpotifyOAuth(SpotifyAuthBase):
                 f.close()
                 if token_info_string != '':
                     token_info = json.loads(token_info_string)
-                token_info = ''
 
                 # if scopes don't match, then bail
                 if "scope" not in token_info or not self._is_scope_subset(

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -284,7 +284,9 @@ class SpotifyOAuth(SpotifyAuthBase):
                 f = open(self.cache_path)
                 token_info_string = f.read()
                 f.close()
-                token_info = json.loads(token_info_string)
+                if token_info_string != '':
+                    token_info = json.loads(token_info_string)
+                token_info = ''
 
                 # if scopes don't match, then bail
                 if "scope" not in token_info or not self._is_scope_subset(


### PR DESCRIPTION
I added a check to see if the cache file is an empty string, as this could result in an error in `json.loads(token_info_string)` on line 287
Related open issue is #493 