### PR TITLE
Fix playlist add items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `user_playlist_is_following` in favor of `playlist_is_following`
 - `playlist_tracks` in favor of `playlist_items`
 
+### Fixed
+- fixed issue where episode URIs were being converted to track URIs in playlist calls
+
 ## [2.13.0] - 2020-06-25
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extra_reqs = {
 
 setup(
     name='spotipy',
-    version='2.13.0',
+    version='2.13.1',
     description='A light weight Python library for the Spotify Web API',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extra_reqs = {
 
 setup(
     name='spotipy',
-    version='2.13.1',
+    version='2.13.0',
     description='A light weight Python library for the Spotify Web API',
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1006,7 +1006,7 @@ class Spotify(object):
                 - position - the position to add the tracks
         """
         plid = self._get_id("playlist", playlist_id)
-        ftracks = [self._get_uri("track", tid) for tid in items]
+        ftracks = [self._get_uri("track", tid) if not self._is_uri(tid) else tid for tid in items]
         return self._post(
             "playlists/%s/tracks" % (plid),
             payload=ftracks,
@@ -1825,6 +1825,9 @@ class Spotify(object):
 
     def _get_uri(self, type, id):
         return "spotify:" + type + ":" + self._get_id(type, id)
+
+    def _is_uri(self, uri):
+        return uri.startswith("spotify:") and len(uri.split(':')) == 3
 
     def _search_multiple_markets(self, q, limit, offset, type, markets, total):
         if total and limit > total:

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1006,7 +1006,7 @@ class Spotify(object):
                 - position - the position to add the tracks
         """
         plid = self._get_id("playlist", playlist_id)
-        ftracks = [self._get_uri("track", tid) if not self._is_uri(tid) else tid for tid in items]
+        ftracks = [self._get_uri("track", tid) for tid in items]
         return self._post(
             "playlists/%s/tracks" % (plid),
             payload=ftracks,
@@ -1824,7 +1824,10 @@ class Spotify(object):
         return id
 
     def _get_uri(self, type, id):
-        return "spotify:" + type + ":" + self._get_id(type, id)
+        if self._is_uri(id):
+            return id
+        else:
+            return "spotify:" + type + ":" + self._get_id(type, id)
 
     def _is_uri(self, uri):
         return uri.startswith("spotify:") and len(uri.split(':')) == 3

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -36,8 +36,8 @@ class AuthTestSpotipy(unittest.TestCase):
 
     bad_id = 'BAD_ID'
 
-    creep_urn = 'spotify:track:3HfB5hBU0dmBt8T0iCmH42'
-    creep_id = '3HfB5hBU0dmBt8T0iCmH42'
+    creep_urn = 'spotify:track:6b2oQwSGFkzsMtQruIWm2p'
+    creep_id = '6b2oQwSGFkzsMtQruIWm2p'
     creep_url = 'http://open.spotify.com/track/3HfB5hBU0dmBt8T0iCmH42'
     el_scorcho_urn = 'spotify:track:0Svkvt5I79wficMFgaqEQJ'
     el_scorcho_bad_urn = 'spotify:track:0Svkvt5I79wficMFgaqEQK'

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -38,7 +38,7 @@ class AuthTestSpotipy(unittest.TestCase):
 
     creep_urn = 'spotify:track:6b2oQwSGFkzsMtQruIWm2p'
     creep_id = '6b2oQwSGFkzsMtQruIWm2p'
-    creep_url = 'http://open.spotify.com/track/3HfB5hBU0dmBt8T0iCmH42'
+    creep_url = 'http://open.spotify.com/track/6b2oQwSGFkzsMtQruIWm2p'
     el_scorcho_urn = 'spotify:track:0Svkvt5I79wficMFgaqEQJ'
     el_scorcho_bad_urn = 'spotify:track:0Svkvt5I79wficMFgaqEQK'
     pinkerton_urn = 'spotify:album:04xe676vyiTeYNXw15o9jT'

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -25,6 +25,17 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
                             "spotify:track:1PB7gRWcvefzu7t3LJLUlf"]
         cls.username = os.getenv(CCEV['client_username'])
 
+        # be wary here, episodes sometimes go away forever
+        # which could cause tests that rely on four_episodes
+        # to fail
+
+        cls.four_episodes = [
+            "spotify:episode:7f9e73vfXKRqR6uCggK2Xy",
+            "spotify:episode:4wA1RLFNOWCJ8iprngXmM0",
+            "spotify:episode:32vhLjJjT7m3f9DFCJUCVZ",
+            "spotify:episode:7cRcsGYYRUFo1OF3RgRzdx",
+        ]
+
         scope = (
             'playlist-modify-public '
             'user-library-read '
@@ -122,6 +133,22 @@ class SpotipyPlaylistApiTest(unittest.TestCase):
 
         self.spotify.playlist_remove_all_occurrences_of_items(
             self.new_playlist['id'], self.other_tracks)
+        playlist = self.spotify.playlist_items(self.new_playlist['id'])
+        self.assertEqual(playlist["total"], 0)
+
+    def test_playlist_add_episodes(self):
+        # add episodes to playlist
+        self.spotify.playlist_add_items(
+            self.new_playlist['id'], self.four_episodes)
+        playlist = self.spotify.playlist_items(self.new_playlist['id'])
+        self.assertEqual(playlist['total'], 4)
+        self.assertEqual(len(playlist['items']), 4)
+
+        pl = self.spotify.playlist_items(self.new_playlist['id'], limit=2)
+        self.assertEqual(len(pl["items"]), 2)
+
+        self.spotify.playlist_remove_all_occurrences_of_items(
+            self.new_playlist['id'], self.four_episodes)
         playlist = self.spotify.playlist_items(self.new_playlist['id'])
         self.assertEqual(playlist["total"], 0)
 


### PR DESCRIPTION
The playlist_add_items method did not work if the given items were episodes. This was because all uris were being converted to track uris. I've changed this so that URIs are no longer automatically converted to track uris.

Also, in the unittests, the track uris and ids for 'Creep' were old causing the 'popularity' test to fail. I changed the URI to a more recent one to fix the tests.