### PR TITLE
Adds option to retrieve currently playing podcast episode. Fixes #562

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1620,21 +1620,23 @@ class Spotify(object):
         """
         return self._get("me/player/devices")
 
-    def current_playback(self, market=None):
+    def current_playback(self, market=None, additional_types=None):
         """ Get information about user's current playback.
 
             Parameters:
                 - market - an ISO 3166-1 alpha-2 country code.
+                - additional_types - `episode` to get podcast track information
         """
-        return self._get("me/player", market=market)
+        return self._get("me/player", market=market, additional_types=additional_types)
 
-    def currently_playing(self, market=None):
+    def currently_playing(self, market=None, additional_types=None):
         """ Get user's currently playing track.
 
             Parameters:
                 - market - an ISO 3166-1 alpha-2 country code.
+                - additional_types - `episode` to get podcast track information
         """
-        return self._get("me/player/currently-playing", market=market)
+        return self._get("me/player/currently-playing", market=market, additional_types=additional_types)
 
     def transfer_playback(self, device_id, force_play=True):
         """ Transfer playback to another device.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1637,7 +1637,7 @@ class Spotify(object):
                 - additional_types - `episode` to get podcast track information
         """
         return self._get("me/player/currently-playing", market=market,
-            additional_types=additional_types)
+                         additional_types=additional_types)
 
     def transfer_playback(self, device_id, force_play=True):
         """ Transfer playback to another device.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1636,7 +1636,8 @@ class Spotify(object):
                 - market - an ISO 3166-1 alpha-2 country code.
                 - additional_types - `episode` to get podcast track information
         """
-        return self._get("me/player/currently-playing", market=market, additional_types=additional_types)
+        return self._get("me/player/currently-playing", market=market,
+            additional_types=additional_types)
 
     def transfer_playback(self, device_id, force_play=True):
         """ Transfer playback to another device.


### PR DESCRIPTION
Adds option to pass `additional_types` to the currently_playing and current_playback.
This allows to get currently playing podcast episodes, not only tracks.  

[Reference to docs](https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-information-about-the-users-current-playback)
