### PR TITLE
Made cache_path and username optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SpotifyPKCE.parse_auth_response_url`, mirroring that method in
  `SpotifyOAuth`
 
+### Changed
+
+- Specifying a cache_path or username is now optional
+
 ### Fixed
 
 - Using `SpotifyPKCE.get_authorization_url` will now generate a code

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ from spotipy.oauth2 import SpotifyOAuth
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(client_id="YOUR_APP_CLIENT_ID",
                                                client_secret="YOUR_APP_CLIENT_SECRET",
                                                redirect_uri="YOUR_APP_REDIRECT_URI",
-                                               username="YOUR_SPOTIFY_USERNAME",
                                                scope="user-library-read"))
 
 results = sp.current_user_saved_tracks()

--- a/examples/my_top_tracks.py
+++ b/examples/my_top_tracks.py
@@ -1,15 +1,7 @@
 # Shows the top tracks for a user
 
-import sys
-
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
-
-if len(sys.argv) > 1:
-    username = sys.argv[1]
-else:
-    print("Usage: %s username" % (sys.argv[0],))
-    sys.exit()
 
 scope = 'user-top-read'
 sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))

--- a/examples/remove_specific_tracks_from_playlist.py
+++ b/examples/remove_specific_tracks_from_playlist.py
@@ -15,7 +15,7 @@ if len(sys.argv) > 2:
         track_ids.append({"uri": tid, "positions": [int(pos)]})
 else:
     print(
-        "Usage: %s username playlist_id track_id,pos track_id,pos ..." %
+        "Usage: %s playlist_id track_id,pos track_id,pos ..." %
         (sys.argv[0],))
     sys.exit()
 

--- a/examples/replace_tracks_in_playlist.py
+++ b/examples/replace_tracks_in_playlist.py
@@ -10,7 +10,7 @@ if len(sys.argv) > 3:
     playlist_id = sys.argv[1]
     track_ids = sys.argv[2:]
 else:
-    print("Usage: %s username playlist_id track_id ..." % (sys.argv[0],))
+    print("Usage: %s playlist_id track_id ..." % (sys.argv[0],))
     sys.exit()
 
 scope = 'playlist-modify-public'

--- a/examples/show_user.py
+++ b/examples/show_user.py
@@ -1,5 +1,4 @@
-
-# shows artist info for a URN or URL
+# Shows artist info for a URN or URL
 
 from spotipy.oauth2 import SpotifyClientCredentials
 import spotipy

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -852,9 +852,9 @@ class SpotifyPKCE(SpotifyAuthBase):
             raise SpotifyOauthError('error: {0}, error_descr: {1}'.format(error_payload['error'],
                                                                           error_payload[
                                                                               'error_description'
-                                                                              ]),
-                                    error=error_payload['error'],
-                                    error_description=error_payload['error_description'])
+            ]),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
         self._save_token_info(token_info)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -256,11 +256,14 @@ class SpotifyOAuth(SpotifyAuthBase):
              * redirect_uri: Must be supplied or set as environment variable
              * state: May be supplied, no verification is performed
              * scope: May be supplied, intuitively converted to proper format
-             * cache_path: May be supplied, will otherwise be generated (takes precedence over `username`)
-             * username: May be supplied or set as environment variable (will set `cache_path` to `.cache-{username}`)
+             * cache_path: May be supplied, will otherwise be generated
+                           (takes precedence over `username`)
+             * username: May be supplied or set as environment variable
+                         (will set `cache_path` to `.cache-{username}`)
              * proxies: Proxy for the requests library to route through
              * show_dialog: Interpreted as boolean
-             * requests_timeout: Tell Requests to stop waiting for a response after a given number of seconds
+             * requests_timeout: Tell Requests to stop waiting for a response after a given number
+                                 of seconds
         """
 
         super(SpotifyOAuth, self).__init__(requests_session)
@@ -591,11 +594,14 @@ class SpotifyPKCE(SpotifyAuthBase):
              * redirect_uri: Must be supplied or set as environment variable
              * state: May be supplied, no verification is performed
              * scope: May be supplied, intuitively converted to proper format
-             * cache_path: May be supplied, will otherwise be generated (takes precedence over `username`)
-             * username: May be supplied or set as environment variable (will set `cache_path` to `.cache-{username}`)
+             * cache_path: May be supplied, will otherwise be generated
+                           (takes precedence over `username`)
+             * username: May be supplied or set as environment variable
+                         (will set `cache_path` to `.cache-{username}`)
              * show_dialog: Interpreted as boolean
              * proxies: Proxy for the requests library to route through
-             * requests_timeout: Tell Requests to stop waiting for a response after a given number of seconds
+             * requests_timeout: Tell Requests to stop waiting for a response after a given number
+                                 of seconds
         """
 
         super(SpotifyPKCE, self).__init__(requests_session)
@@ -969,8 +975,10 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         * redirect_uri: Must be supplied or set as environment variable
         * state: May be supplied, no verification is performed
         * scope: May be supplied, intuitively converted to proper format
-        * cache_path: May be supplied, will otherwise be generated (takes precedence over `username`)
-        * username: May be supplied or set as environment variable (will set `cache_path` to `.cache-{username}`)
+        * cache_path: May be supplied, will otherwise be generated
+                      (takes precedence over `username`)
+        * username: May be supplied or set as environment variable
+                    (will set `cache_path` to `.cache-{username}`)
         * show_dialog: Interpreted as boolean
         """
         self.client_id = client_id

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -304,7 +304,7 @@ class SpotifyOAuth(SpotifyAuthBase):
                 )
 
         except IOError:
-            pass
+            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -774,7 +774,7 @@ class SpotifyPKCE(SpotifyAuthBase):
                 )
 
         except IOError:
-            pass
+            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -1013,7 +1013,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
                 return None
 
         except IOError:
-            pass
+            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -21,7 +21,7 @@ CLIENT_CREDS_ENV_VARS = {
 
 
 def prompt_for_user_token(
-    username,
+    username=None,
     scope=None,
     client_id=None,
     client_secret=None,
@@ -43,14 +43,14 @@ def prompt_for_user_token(
 
         Parameters:
 
-         - username - the Spotify username
-         - scope - the desired scope of the request
-         - client_id - the client id of your app
-         - client_secret - the client secret of your app
-         - redirect_uri - the redirect URI of your app
-         - cache_path - path to location to save tokens
-         - oauth_manager - Oauth manager object.
-         - show_dialog - If true, a login prompt always shows
+         - username - the Spotify username (optional)
+         - scope - the desired scope of the request (optional)
+         - client_id - the client id of your app (required)
+         - client_secret - the client secret of your app (required)
+         - redirect_uri - the redirect URI of your app (required)
+         - cache_path - path to location to save tokens (optional)
+         - oauth_manager - Oauth manager object (optional)
+         - show_dialog - If true, a login prompt always shows (optional, defaults to False)
 
     """
     if not oauth_manager:
@@ -79,14 +79,13 @@ def prompt_for_user_token(
             )
             raise spotipy.SpotifyException(550, -1, "no credentials set")
 
-        cache_path = cache_path or ".cache-" + username
-
     sp_oauth = oauth_manager or spotipy.SpotifyOAuth(
         client_id,
         client_secret,
         redirect_uri,
         scope=scope,
         cache_path=cache_path,
+        username=username,
         show_dialog=show_dialog
     )
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -436,8 +436,8 @@ class TestSpotifyPKCE(unittest.TestCase):
         auth.get_pkce_handshake_parameters()
         self.assertEqual(auth.code_challenge,
                          base64.urlsafe_b64encode(
-                                hashlib.sha256(auth.code_verifier.encode('utf-8'))
-                                .digest())
+                             hashlib.sha256(auth.code_verifier.encode('utf-8'))
+                             .digest())
                          .decode('utf-8')
                          .replace('=', ''))
 


### PR DESCRIPTION
As suggested here https://github.com/plamere/spotipy/issues/533#issuecomment-682304023

The API itself does not require a username but Spotipy was still asking for it in order to know where to store the token. 

I think most devs want to get started quickly and will by default only use their main account, so storing that main account token in a cache called `.cache` should be fine.

Apps that specify a username should still work.

Fixes https://github.com/plamere/spotipy/issues/507, https://github.com/plamere/spotipy/issues/512, https://github.com/plamere/spotipy/issues/549

