### PR TITLE
Allow open_browser to be set on creation of auth_manager (SpotifyOAuth/SpotifyPKCE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+### Added
+
+- `open_browser` can be passed to the constructors of `SpotifyOAuth` and `SpotifyPKCE` to make it easier to authorize in browserless environments
 
 ## [2.15.0] - 2020-09-08
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,3 +41,10 @@ Problem: you can see a track on the Spotify app but searching for it using the A
 Solution: by default `search("abba")` works in the US market.
 To search for in your current country, the [country indicator](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
 must be specified: `search("abba", market="DE")`.
+
+### How do I obtain authorization in a headless/browserless environment?
+
+If you cannot open a browser, set `open_browser=False` when instantiating SpotifyOAuth or SpotifyPKCE. You will be
+prompted to open the authorization URI manually.  
+
+See the [headless auth example](examples/headless.py).

--- a/examples/headless.py
+++ b/examples/headless.py
@@ -1,0 +1,8 @@
+import spotipy
+
+from spotipy.oauth2 import SpotifyOAuth
+
+# set open_browser=False to prevent Spotipy from attempting to open the default browser
+spotify = spotipy.Spotify(auth_manager=SpotifyOAuth(open_browser=False))
+
+print(spotify.me())

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -386,7 +386,7 @@ class SpotifyOAuth(SpotifyAuthBase):
             logger.error("Please navigate here: %s", auth_url)
 
     def _get_auth_response_interactive(self, open_browser=False):
-        if open_browser or self.open_browser:
+        if open_browser:
             self._open_auth_url()
             prompt = "Enter the URL you were redirected to: "
         else:
@@ -416,7 +416,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         else:
             raise SpotifyOauthError("Server listening on localhost has not been accessed")
 
-    def get_auth_response(self, open_browser=False):
+    def get_auth_response(self, open_browser=None):
         logger.info('User authentication requires interaction with your '
                     'web browser. Once you enter your credentials and '
                     'give authorization, you will be redirected to '
@@ -425,6 +425,9 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         redirect_info = urlparse(self.redirect_uri)
         redirect_host, redirect_port = get_host_port(redirect_info.netloc)
+
+        if open_browser is None:
+            open_browser = self.open_browser
 
         if (
                 (open_browser or self.open_browser)
@@ -694,7 +697,7 @@ class SpotifyPKCE(SpotifyAuthBase):
         except webbrowser.Error:
             logger.error("Please navigate here: %s", auth_url)
 
-    def _get_auth_response(self, open_browser=False):
+    def _get_auth_response(self, open_browser=None):
         logger.info('User authentication requires interaction with your '
                     'web browser. Once you enter your credentials and '
                     'give authorization, you will be redirected to '
@@ -704,8 +707,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         redirect_info = urlparse(self.redirect_uri)
         redirect_host, redirect_port = get_host_port(redirect_info.netloc)
 
+        if open_browser is None:
+            open_browser = self.open_browser
+
         if (
-                (open_browser or self.open_browser)
+                open_browser
                 and redirect_host in ("127.0.0.1", "localhost")
                 and redirect_info.scheme == "http"
         ):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -864,9 +864,9 @@ class SpotifyPKCE(SpotifyAuthBase):
             raise SpotifyOauthError('error: {0}, error_descr: {1}'.format(error_payload['error'],
                                                                           error_payload[
                                                                               'error_description'
-                                                                          ]),
-                                    error=error_payload['error'],
-                                    error_description=error_payload['error_description'])
+            ]),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
         self._save_token_info(token_info)


### PR DESCRIPTION
This PR fixes #560 (and possibly #572)

One can now instantiate SpotifyOAuth or SpotifyPKCE with `open_browser` set to `False`, behaving the same as if you had called `get_auth_response(open_browser=False)`. For backwards compatibility, this defaults to `True`.

Example:

```python
import spotipy

from spotipy.oauth2 import SpotifyOAuth

oauth = SpotifyOAuth(scope="streaming", open_browser=False)

spotify = spotipy.Spotify(auth_manager=oauth)

if __name__ == "__main__":
    spotify.start_playback()
```