### PR TITLE
Fixed UnboundLocalError / AttributeError #571, #581

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+### Fixed
+
+- SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
 ## [2.16.0] - 2020-09-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
-### Added
-
-- `test_max_entries_reached` added to integration test suite - validates fix to #571, #581 
-
 ## [2.16.0] - 2020-09-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
+### Added
+
+- `test_max_entries_reached` added to integration test suite - validates fix to #571, #581 
+
 ## [2.16.0] - 2020-09-16
 
 ### Added

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -22,6 +22,7 @@ class AuthTestSpotipy(unittest.TestCase):
     """
 
     playlist = "spotify:user:plamere:playlist:2oCEWyyAPbZp9xhVSxZavx"
+    playlist_id = "2oCEWyyAPbZp9xhVSxZavx"
     four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
                    "spotify:track:7IHOIqZUUInxjVkko181PB",
                    "4VrWlk8IQxevMvERoX08iC",
@@ -239,6 +240,13 @@ class AuthTestSpotipy(unittest.TestCase):
         # depending on the timing or bandwidth, this raises a timeout or connection error"
         self.assertRaises((requests.exceptions.Timeout, requests.exceptions.ConnectionError),
                           lambda: sp.search(q='my*', type='track'))
+
+    def test_max_retries_reached(self):
+        client_credentials_manager = SpotifyClientCredentials()
+        sp = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
+        self.assertRaises((spotipy.exceptions.SpotifyException,),
+                          lambda: sp.playlist_is_following(playlist_id=AuthTestSpotipy.playlist_id,
+                                                           user_ids=[AuthTestSpotipy.bad_id]))
 
     def test_album_search(self):
         results = self.spotify.search(q='weezer pinkerton', type='album')

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -242,11 +242,18 @@ class AuthTestSpotipy(unittest.TestCase):
                           lambda: sp.search(q='my*', type='track'))
 
     def test_max_retries_reached(self):
-        client_credentials_manager = SpotifyClientCredentials()
-        sp = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
-        self.assertRaises((spotipy.exceptions.SpotifyException,),
-                          lambda: sp.playlist_is_following(playlist_id=AuthTestSpotipy.playlist_id,
-                                                           user_ids=[AuthTestSpotipy.bad_id]))
+        spotify_no_retry = Spotify(
+            client_credentials_manager=SpotifyClientCredentials(),
+            retries=0)
+        i = 0
+        while i < 100:
+            try:
+                spotify_no_retry.search(q='foo')
+            except spotipy.exceptions.SpotifyException as e:
+                self.assertIsInstance(e, spotipy.exceptions.SpotifyException)
+                return
+            i += 1
+        self.fail()
 
     def test_album_search(self):
         results = self.spotify.search(q='weezer pinkerton', type='album')

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -22,7 +22,6 @@ class AuthTestSpotipy(unittest.TestCase):
     """
 
     playlist = "spotify:user:plamere:playlist:2oCEWyyAPbZp9xhVSxZavx"
-    playlist_id = "2oCEWyyAPbZp9xhVSxZavx"
     four_tracks = ["spotify:track:6RtPijgfPKROxEzTHNRiDp",
                    "spotify:track:7IHOIqZUUInxjVkko181PB",
                    "4VrWlk8IQxevMvERoX08iC",


### PR DESCRIPTION
Have also added an integration test to confirm that when max entries is reached, SpotifyException is thrown, and not the unexpected errors noted in issues #571 and #581.

Fixes #571 and #581.