### PR TITLE
isort Module is Observed in /spotipy/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
-## [2.16.0] - 2020-09-18
-
 ### Changed
 
 - both inline and starting import lists are sorted using `isort` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## Unreleased
 
 ### Fixed
 
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
+
+## [2.16.0] - 2020-09-18
+
+### Changed
+
+- both inline and starting import lists are sorted using `isort` module
 
 ## [2.16.0] - 2020-09-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,11 @@ To verify the code style:
     pip install flake8
     flake8 .
 
+To make sure if the import lists are stored correctly:
+
+    pip install isort
+    isort . -c -v
+
 ### Changelog
 
 Don't forget to add a short description of your change in the [CHANGELOG](CHANGELOG.md)

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,4 +1,4 @@
 from .client import *  # noqa
+from .exceptions import *  # noqa
 from .oauth2 import *  # noqa
 from .util import *  # noqa
-from .exceptions import *  # noqa

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -9,8 +9,8 @@ import logging
 import warnings
 
 import requests
-import urllib3
 import six
+import urllib3
 
 from spotipy.exceptions import SpotifyException
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -19,14 +19,14 @@ import warnings
 import webbrowser
 
 import requests
-from spotipy.util import CLIENT_CREDS_ENV_VARS, get_host_port
-from spotipy.exceptions import SpotifyException
-
 # Workaround to support both python 2 & 3
 import six
 import six.moves.urllib.parse as urllibparse
-from six.moves.BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
-from six.moves.urllib_parse import urlparse, parse_qsl
+from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from six.moves.urllib_parse import parse_qsl, urlparse
+
+from spotipy.exceptions import SpotifyException
+from spotipy.util import CLIENT_CREDS_ENV_VARS, get_host_port
 
 logger = logging.getLogger(__name__)
 
@@ -652,8 +652,8 @@ class SpotifyPKCE(SpotifyAuthBase):
             import secrets
             verifier = secrets.token_urlsafe(length)
         except ImportError:  # For python 3.5 support
-            import os
             import base64
+            import os
             rand_bytes = os.urandom(length)
             verifier = base64.urlsafe_b64encode(rand_bytes).decode('utf-8').replace('=', '')
         return verifier
@@ -663,8 +663,8 @@ class SpotifyPKCE(SpotifyAuthBase):
         Reference:
         https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
         """
-        import hashlib
         import base64
+        import hashlib
         code_challenge_digest = hashlib.sha256(self.code_verifier.encode('utf-8')).digest()
         code_challenge = base64.urlsafe_b64encode(code_challenge_digest).decode('utf-8')
         return code_challenge.replace('=', '')


### PR DESCRIPTION
I installed the `isort` module right beside the other dependencies. Now, isort is observed in /spotipy/*.py files. There is no big change in the main algorithm.

> I'm contributing in Hacktoberfest challenge. Be sure that I'll make some essential changes in the project. I just need to add the "hacktoberfest" label in this PR.

Thanks.