### PR TITLE
Default Script-based Configurations is set for Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+### Added
 
-- SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
+- Base script-based configurations observed for `logging` side
 
 ### Changed
 
 - both inline and starting import lists are sorted using `isort` module
+
+### Fixed
+
+- SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
 ## [2.16.0] - 2020-09-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ export SPOTIPY_REDIRECT_URI=http://localhost:8080 # Make url is set in app you c
 
 ```bash
 $ virtualenv --python=python3.7 env
-(env) $ pip install --user -e .
+(env) $ pip install -e .
 (env) $ python -m unittest discover -v tests
 ```
 

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -5,11 +5,17 @@
 __all__ = ["CLIENT_CREDS_ENV_VARS", "prompt_for_user_token"]
 
 import logging
+import logging.config
 import os
 import warnings
 
 import spotipy
 
+logging.basicConfig(
+    level=logging.WARNING,
+    format='%(asctime)s %(levelname)-8s %(name)-15s %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S',
+)
 LOGGER = logging.getLogger(__name__)
 
 CLIENT_CREDS_ENV_VARS = {


### PR DESCRIPTION
In most cases, It's better to create a base configuration for `logging` which is easily available on [structlog](https://www.structlog.org/en/stable/standard-library.html) too. Not a big difference to either use a YML, or a JSON based method for configurations. Most often we use the external methods when we are trying to focus on the logging side. Base configurations allow you to override the original classes and have your own configurations.

#### Changes
- `CHANGELOG.md` file ~ "Unreleased" section: Subsections are sorted alphabetically and the new changes and adds are explained.
- `CONTRIBUTING.md` file ~ "Create virtual environment" section: When you create a virtual environment, there is no need to use `--user` flag in the installation process. In some cases, it might break the installation cycle. Packages are being installed in the virtual environment by default, but if you use `--user`, it will force it to install outside the virtual environments.

> I enthusiastically appreciate it if you add the `hacktoberfest` label to this PR too. Thank you.