### PR TITLE
Fixed output of playlist_tracks example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-
+- playlist_tracks example code no longer prints extra characters on final loop iteration
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
 
 ### Changed

--- a/examples/playlist_tracks.py
+++ b/examples/playlist_tracks.py
@@ -12,9 +12,10 @@ while True:
                                  offset=offset,
                                  fields='items.track.id,total',
                                  additional_types=['track'])
+    
+    if len(response['items']) == 0:
+        break
+    
     pprint(response['items'])
     offset = offset + len(response['items'])
     print(offset, "/", response['total'])
-
-    if len(response['items']) == 0:
-        break


### PR DESCRIPTION
Output of playlist_tracks example no longer outputs extra characters on final loop iteration.