### PR TITLE
Added scope, 'playlist-read-private', to examples that access user playlists using the spotipy api: current_user_playlists() (fixes #591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - SpotifyException now thrown when a request fails & has no response ( fixes #571, #581 )
+- Added scope, 'playlist-read-private', to examples that access user playlists using the spotipy api: current_user_playlists() (fixes #591)
 
 ### Changed
 

--- a/examples/my_playlists.py
+++ b/examples/my_playlists.py
@@ -3,7 +3,8 @@
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
-sp = spotipy.Spotify(auth_manager=SpotifyOAuth())
+scope = 'playlist-read-private'
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
 results = sp.current_user_playlists(limit=50)
 for i, item in enumerate(results['items']):

--- a/examples/user_playlists.py
+++ b/examples/user_playlists.py
@@ -1,11 +1,19 @@
 # Shows a user's playlists (need to be authenticated via oauth)
 
+import sys
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
-scope = 'playlist-read-private'
-sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-playlists = sp.current_user_playlists()
+if len(sys.argv) > 1:
+    username = sys.argv[1]
+else:
+    print("Whoops, need a username!")
+    print("usage: python user_playlists.py [username]")
+    sys.exit()
+
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth())
+
+playlists = sp.user_playlists(username)
 
 for playlist in playlists['items']:
     print(playlist['name'])

--- a/examples/user_playlists.py
+++ b/examples/user_playlists.py
@@ -3,7 +3,8 @@
 import spotipy
 from spotipy.oauth2 import SpotifyOAuth
 
-sp = spotipy.Spotify(auth_manager=SpotifyOAuth())
+scope = 'playlist-read-private'
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 playlists = sp.current_user_playlists()
 
 for playlist in playlists['items']:

--- a/examples/user_playlists_contents.py
+++ b/examples/user_playlists_contents.py
@@ -13,7 +13,8 @@ def show_tracks(results):
 
 
 if __name__ == '__main__':
-    sp = spotipy.Spotify(auth_manager=SpotifyOAuth())
+    scope = 'playlist-read-private'
+    sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
 
     playlists = sp.current_user_playlists()
     user_id = sp.me()['id']


### PR DESCRIPTION
Added scope, 'playlist-read-private', to examples that access user playlists using the spotipy api: current_user_playlists() (fixes #591)