### PR TITLE
Suppress warnings when cache path does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+- A warning will no longer be emitted when the cache file does not exist at the specified path
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
 
 ## [2.16.1] - 2020-10-24
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -114,7 +114,7 @@ class Spotify(object):
         """
         Creates a Spotify API client.
 
-        :param auth: An authorization token (optional)
+        :param auth: An access token (optional)
         :param requests_session:
             A Requests session object or a truthy value to create one.
             A falsy value disables sessions.

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -289,27 +289,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +770,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1019,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                return None
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    return None
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -306,6 +306,8 @@ class SpotifyOAuth(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -785,6 +787,8 @@ class SpotifyPKCE(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -1030,6 +1034,8 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
             if self.is_token_expired(token_info):
                 return None
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 import base64
+import errno
 import json
 import logging
 import os
@@ -289,27 +290,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +771,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1020,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    return None
-            except IOError:
+            if self.is_token_expired(token_info):
+                return None
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 


### PR DESCRIPTION
See issue #605 

I also changed the docs for `auth` parameter of `Spotify.init` to "access token" instead of "authorization token". In issue #599, a user confused the access token with the authorization code.