### PR TITLE
Added more logging and fixed docs for search endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - moved os.remove(session_cache_path()) inside try block to avoid TypeError on app.py example file
 - A warning will no longer be emitted when the cache file does not exist at the specified path
-- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"
+- Changed docs for `search` to mention that you can provide multiple multiple types to search for
+- The query parameters of requests are now logged
+
+### Added
+
+- Added log messages for when the access token and refresh tokens are retrieved and when they are refreshed
+
+    
 
 ## [2.16.1] - 2020-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+- A warning will no longer be emitted when the cache file does not exist at the specified path
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
 
 ## [2.16.1] - 2020-10-24
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -233,8 +233,8 @@ class Spotify(object):
         if self.language is not None:
             headers["Accept-Language"] = self.language
 
-        logger.debug('Sending %s to %s with Headers: %s and Body: %r ',
-                     method, url, headers, args.get('data'))
+        logger.debug('Sending %s to %s with Params: %s Headers: %s and Body: %r ',
+                     method, url, args.get("params"), headers, args.get('data'))
 
         try:
             response = self._session.request(
@@ -534,10 +534,12 @@ class Spotify(object):
             Parameters:
                 - q - the search query (see how to write a query in the
                       official documentation https://developer.spotify.com/documentation/web-api/reference/search/search/)  # noqa
-                - limit  - the number of items to return (min = 1, default = 10, max = 50)
+                - limit - the number of items to return (min = 1, default = 10, max = 50). The limit is applied
+                          within each type, not on the total response.
                 - offset - the index of the first item to return
-                - type - the type of item to return. One of 'artist', 'album',
-                         'track', 'playlist', 'show', or 'episode'
+                - type - the types of items to return. One or more of 'artist', 'album',
+                         'track', 'playlist', 'show', and 'episode'.  If multiple types are desired,
+                         pass in a comma separated string; e.g., 'track,album,episode'.
                 - market - An ISO 3166-1 alpha-2 country code or the string
                            from_token.
         """
@@ -554,8 +556,8 @@ class Spotify(object):
                 - limit  - the number of items to return (min = 1, default = 10, max = 50). If a search is to be done on multiple
                             markets, then this limit is applied to each market. (e.g. search US, CA, MX each with a limit of 10).
                 - offset - the index of the first item to return
-                - type - the type's of item's to return. One or more of 'artist', 'album',
-                         'track', 'playlist', 'show', or 'episode'. If multiple types are desired, pass in a comma separated list.
+                - type - the types of items to return. One or more of 'artist', 'album',
+                         'track', 'playlist', 'show', or 'episode'. If multiple types are desired, pass in a comma separated string.
                 - markets - A list of ISO 3166-1 alpha-2 country codes. Search all country markets by default.
                 - total - the total number of results to return if multiple markets are supplied in the search.
                           If multiple types are specified, this only applies to the first type.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -114,7 +114,7 @@ class Spotify(object):
         """
         Creates a Spotify API client.
 
-        :param auth: An authorization token (optional)
+        :param auth: An access token (optional)
         :param requests_session:
             A Requests session object or a truthy value to create one.
             A falsy value disables sessions.

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -289,27 +289,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +770,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1019,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                return None
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    return None
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -197,6 +197,11 @@ class SpotifyClientCredentials(SpotifyAuthBase):
             self.client_id, self.client_secret
         )
 
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
+
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
             data=payload,
@@ -494,6 +499,11 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         headers = self._make_authorization_headers()
 
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
+
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
             data=payload,
@@ -528,6 +538,11 @@ class SpotifyOAuth(SpotifyAuthBase):
         }
 
         headers = self._make_authorization_headers()
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
@@ -836,8 +851,8 @@ class SpotifyPKCE(SpotifyAuthBase):
 
             Parameters:
                 - code - the response code from authentication
-                - check_cache - if true, checks for locally stored token
-                                before requesting a new token if True
+                - check_cache - if true, checks for a locally stored token
+                                before requesting a new token
         """
 
         if check_cache:
@@ -861,6 +876,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
@@ -891,6 +911,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -306,6 +306,8 @@ class SpotifyOAuth(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -785,6 +787,8 @@ class SpotifyPKCE(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -1030,6 +1034,8 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
             if self.is_token_expired(token_info):
                 return None
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 import base64
+import errno
 import json
 import logging
 import os
@@ -289,27 +290,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +771,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1020,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    return None
-            except IOError:
+            if self.is_token_expired(token_info):
+                return None
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 


### PR DESCRIPTION
Logging the requests for retrieving the tokens and refreshing the tokens will make it easier to debug issues that users have with the library. For example, we could've solved #605 faster if these log messages were emitted. I also fixed the docs for the search endpoint to mention that you *can* search for multiple types at the same time. 