### PR TITLE
Add market argument to track info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - moved os.remove(session_cache_path()) inside try block to avoid TypeError on app.py example file
 - A warning will no longer be emitted when the cache file does not exist at the specified path
-- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"
+- Support `market` optional parameter in `track`  
 
 ## [2.16.1] - 2020-10-24
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -327,15 +327,16 @@ class Spotify(object):
         else:
             return None
 
-    def track(self, track_id):
+    def track(self, track_id, market=None):
         """ returns a single track given the track's ID, URI or URL
 
             Parameters:
                 - track_id - a spotify URI, URL or ID
+                - market - an ISO 3166-1 alpha-2 country code.
         """
 
         trid = self._get_id("track", track_id)
-        return self._get("tracks/" + trid)
+        return self._get("tracks/" + trid, market=market)
 
     def tracks(self, tracks, market=None):
         """ returns a list of tracks given a list of track IDs, URIs, or URLs


### PR DESCRIPTION
New PR instead of https://github.com/plamere/spotipy/pull/607

So that we know if a track is available to be played in a specific country.

I've been using this successfully in production (through a forked version) at https://github.com/z1lc/zdone/blob/e5d56f32b17b45975a64e092f4449c20197c2015/app/spotify.py#L351.