### PR TITLE
Fix examples for saved tracks

### DIFF
--- a/examples/contains_a_saved_track.py
+++ b/examples/contains_a_saved_track.py
@@ -1,3 +1,5 @@
+# Prints whether a track exists in your collection of saved tracks
+
 import pprint
 import sys
 
@@ -7,11 +9,11 @@ from spotipy.oauth2 import SpotifyOAuth
 scope = 'user-library-read'
 
 if len(sys.argv) > 1:
-    tids = sys.argv[1]
+    tid = sys.argv[1]
 else:
     print("Usage: %s track-id ..." % (sys.argv[0],))
     sys.exit()
 
-    results = spotipy.current_user_saved_tracks_contains(tracks=tids)
-    pprint.pprint(results)
-
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
+results = sp.current_user_saved_tracks_contains(tracks=[tid])
+pprint.pprint(results)

--- a/examples/delete_a_saved_track.py
+++ b/examples/delete_a_saved_track.py
@@ -9,11 +9,11 @@ from spotipy.oauth2 import SpotifyOAuth
 scope = 'user-library-modify'
 
 if len(sys.argv) > 1:
-    tids = sys.argv[1]
+    tid = sys.argv[1]
 else:
     print("Usage: %s track-id ..." % (sys.argv[0],))
     sys.exit()
 
-    sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
-    results = sp.current_user_saved_tracks_delete(tracks=tids)
-    pprint.pprint(results)
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope=scope))
+results = sp.current_user_saved_tracks_delete(tracks=[tid])
+pprint.pprint(results)


### PR DESCRIPTION
This PR fixes #622 by fixing the indentation of the last three lines and fixing the way user input is handled.

There are similar errors in contains_a_saved_track.py. This PR fixes those as well.