### PR TITLE
Create CacheHandler to abstract caching tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added log messages for when the access and refresh tokens are retrieved and when they are refreshed
-- Support `market` optional parameter in `track`  
+- Support `market` optional parameter in `track`
+- Added CacheHandler abstraction to allow users to cache tokens in any way they see fit
 
 ## [2.16.1] - 2020-10-24
 

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,3 +1,4 @@
+from .cache_handler import * #noqa
 from .client import *  # noqa
 from .exceptions import *  # noqa
 from .oauth2 import *  # noqa

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,4 +1,4 @@
-from .cache_handler import * #noqa
+from .cache_handler import *  # noqa
 from .client import *  # noqa
 from .exceptions import *  # noqa
 from .oauth2 import *  # noqa

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -1,0 +1,82 @@
+import errno
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+class CacheHandler():
+    """
+    An abstraction layer for handling the caching and retrieval of
+    authorization tokens.
+
+    Custom extensions of this class must implement get_cached_token
+    and save_token_to_cache methods with the same input and output
+    structure as the CacheHandler class.
+    """
+
+    def get_cached_token(self):
+        """
+        Get and return a token_info dictionary object.
+        """
+        # return token_info
+        raise NotImplementedError()
+
+    def save_token_to_cache(self, token_info):
+        """
+        Save a token_info dictionary object to the cache and return None.
+        """
+        raise NotImplementedError()
+        return None
+
+
+class CacheFileHandler(CacheHandler):
+    """
+    Handles reading and writing cached Spotify authorization tokens
+    as json files on disk.
+    """
+
+    def __init__(self,
+                 cache_path=None,
+                 username=None):
+        """
+        Parameters:
+             * cache_path: May be supplied, will otherwise be generated
+                           (takes precedence over `username`)
+             * username: May be supplied or set as environment variable
+                         (will set `cache_path` to `.cache-{username}`)
+        """
+
+        if cache_path:
+            self.cache_path = cache_path
+        else:
+            cache_path = ".cache"
+            if username:
+                cache_path += "-" + str(username)
+            self.cache_path = cache_path
+
+    def get_cached_token(self):
+        token_info = None
+
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
+
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+
+        return token_info
+
+    def save_token_to_cache(self, token_info):
+        try:
+            f = open(self.cache_path, "w")
+            f.write(json.dumps(token_info))
+            f.close()
+        except IOError:
+            logger.warning('Couldn\'t write token to cache at: %s',
+                           self.cache_path)
+

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -4,6 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class CacheHandler():
     """
     An abstraction layer for handling the caching and retrieval of
@@ -79,4 +80,3 @@ class CacheFileHandler(CacheHandler):
         except IOError:
             logger.warning('Couldn\'t write token to cache at: %s',
                            self.cache_path)
-

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -1,3 +1,5 @@
+__all__ = ['CacheHandler', 'CacheFileHandler']
+
 import errno
 import json
 import logging

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -10,8 +10,6 @@ __all__ = [
 ]
 
 import base64
-import errno
-import json
 import logging
 import os
 import time
@@ -72,7 +70,6 @@ def _ensure_value(value, env_key):
         )
         raise SpotifyOauthError(msg)
     return _val
-
 
 
 class SpotifyAuthBase(object):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -360,7 +360,8 @@ class SpotifyOAuth(SpotifyAuthBase):
         self.scope = self._normalize_scope(scope)
         if cache_handler:
             assert issubclass(cache_handler.__class__, CacheHandler), \
-                "cache_handler must be a subclass of CacheHandler: " + str(type(cache_handler)) + " != " + str(CacheHandler)
+                "cache_handler must be a subclass of CacheHandler: " + str(type(cache_handler)) \
+                + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
             self.cache_handler = CacheFileHandler(

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -359,8 +359,8 @@ class SpotifyOAuth(SpotifyAuthBase):
         self.state = state
         self.scope = self._normalize_scope(scope)
         if cache_handler:
-            assert issubclass(type(cache_handler), CacheHandler), \
-                "Invalid cache_handler: " + str(type(cache_handler)) + " != " + str(CacheHandler)
+            assert issubclass(cache_handler.__class__, CacheHandler), \
+                "cache_handler must be a subclass of CacheHandler: " + str(type(cache_handler)) + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
             self.cache_handler = CacheFileHandler(

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -6,9 +6,7 @@ __all__ = [
     "SpotifyOauthError",
     "SpotifyStateError",
     "SpotifyImplicitGrant",
-    "SpotifyPKCE",
-    "CacheHandler",
-    "CacheFileHandler"
+    "SpotifyPKCE"
 ]
 
 import base64
@@ -27,6 +25,7 @@ import six.moves.urllib.parse as urllibparse
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from six.moves.urllib_parse import parse_qsl, urlparse
 
+from spotipy.cache_handler import CacheFileHandler, CacheHandler
 from spotipy.exceptions import SpotifyException
 from spotipy.util import CLIENT_CREDS_ENV_VARS, get_host_port
 
@@ -74,82 +73,6 @@ def _ensure_value(value, env_key):
         raise SpotifyOauthError(msg)
     return _val
 
-
-class CacheHandler():
-    """
-    An abstraction layer for handling the caching and retrieval of
-    authorization tokens.
-
-    Custom extensions of this class must implement get_cached_token
-    and save_token_to_cache methods with the same input and output
-    structure as the CacheHandler class.
-    """
-
-    def get_cached_token(self):
-        """
-        Get and return a token_info dictionary object.
-        """
-        # return token_info
-        raise NotImplementedError()
-
-    def save_token_to_cache(self, token_info):
-        """
-        Save a token_info dictionary object to the cache and return None.
-        """
-        raise NotImplementedError()
-        return None
-
-
-class CacheFileHandler(CacheHandler):
-    """
-    Handles reading and writing cached Spotify authorization tokens
-    as json files on disk.
-    """
-
-    def __init__(self,
-                 cache_path=None,
-                 username=None):
-        """
-        Parameters:
-             * cache_path: May be supplied, will otherwise be generated
-                           (takes precedence over `username`)
-             * username: May be supplied or set as environment variable
-                         (will set `cache_path` to `.cache-{username}`)
-        """
-
-        if cache_path:
-            self.cache_path = cache_path
-        else:
-            cache_path = ".cache"
-            if username:
-                cache_path += "-" + str(username)
-            self.cache_path = cache_path
-
-    def get_cached_token(self):
-        token_info = None
-
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
-
-        except IOError as error:
-            if error.errno == errno.ENOENT:
-                logger.debug("cache does not exist at: %s", self.cache_path)
-            else:
-                logger.warning("Couldn't read cache at: %s", self.cache_path)
-
-        return token_info
-
-    def save_token_to_cache(self, token_info):
-        try:
-            f = open(self.cache_path, "w")
-            f.write(json.dumps(token_info))
-            f.close()
-        except IOError:
-            logger.warning('Couldn\'t write token to cache at: %s',
-                           self.cache_path)
 
 
 class SpotifyAuthBase(object):

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -93,7 +93,7 @@ def prompt_for_user_token(
     # if not in the cache, the create a new (this will send
     # the user to a web page where they can authorize this app)
 
-    token_info = sp_oauth.get_cached_token()
+    token_info = sp_oauth.validate_token(sp_oauth.cache_handler.get_cached_token())
 
     if not token_info:
         code = sp_oauth.get_auth_response()

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -6,7 +6,7 @@ import unittest
 import six.moves.urllib.parse as urllibparse
 
 from spotipy import SpotifyOAuth, SpotifyImplicitGrant, SpotifyPKCE
-from spotipy.cache_handler import CacheHandler, CacheFileHandler
+from spotipy.cache_handler import CacheHandler
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 from spotipy.oauth2 import SpotifyStateError
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -5,7 +5,8 @@ import unittest
 
 import six.moves.urllib.parse as urllibparse
 
-from spotipy import CacheHandler, SpotifyOAuth, SpotifyImplicitGrant, SpotifyPKCE
+from spotipy import SpotifyOAuth, SpotifyImplicitGrant, SpotifyPKCE
+from spotipy.cache_handler import CacheHandler, CacheFileHandler
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 from spotipy.oauth2 import SpotifyStateError
 
@@ -66,7 +67,7 @@ class OAuthCacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyOAuth,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_gets_from_cache_path(self, opener,
                                   is_token_expired, refresh_access_token):
         scope = "playlist-modify-private"
@@ -85,7 +86,7 @@ class OAuthCacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyOAuth,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_expired_token_refreshes(self, opener,
                                      is_token_expired, refresh_access_token):
         scope = "playlist-modify-private"
@@ -106,7 +107,7 @@ class OAuthCacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyOAuth,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_badly_scoped_token_bails(self, opener,
                                       is_token_expired, refresh_access_token):
         token_scope = "playlist-modify-public"
@@ -124,7 +125,7 @@ class OAuthCacheTest(unittest.TestCase):
         self.assertIsNone(cached_tok)
         self.assertEqual(refresh_access_token.call_count, 0)
 
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_saves_to_cache_path(self, opener):
         scope = "playlist-modify-private"
         path = ".cache-username"
@@ -246,7 +247,7 @@ class TestSpotifyClientCredentials(unittest.TestCase):
 class ImplicitGrantCacheTest(unittest.TestCase):
 
     @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_gets_from_cache_path(self, opener, is_token_expired):
         scope = "playlist-modify-private"
         path = ".cache-username"
@@ -262,7 +263,7 @@ class ImplicitGrantCacheTest(unittest.TestCase):
         self.assertIsNotNone(cached_tok)
 
     @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_expired_token_returns_none(self, opener, is_token_expired):
         scope = "playlist-modify-private"
         path = ".cache-username"
@@ -279,7 +280,7 @@ class ImplicitGrantCacheTest(unittest.TestCase):
         self.assertIsNone(cached_tok)
 
     @patch.object(SpotifyImplicitGrant, "is_token_expired", DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_badly_scoped_token_bails(self, opener, is_token_expired):
         token_scope = "playlist-modify-public"
         requested_scope = "playlist-modify-private"
@@ -295,7 +296,7 @@ class ImplicitGrantCacheTest(unittest.TestCase):
         opener.assert_called_with(path)
         self.assertIsNone(cached_tok)
 
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_saves_to_cache_path(self, opener):
         scope = "playlist-modify-private"
         path = ".cache-username"
@@ -365,7 +366,7 @@ class SpotifyPKCECacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyPKCE,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_gets_from_cache_path(self, opener,
                                   is_token_expired, refresh_access_token):
         scope = "playlist-modify-private"
@@ -384,7 +385,7 @@ class SpotifyPKCECacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyPKCE,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_expired_token_refreshes(self, opener,
                                      is_token_expired, refresh_access_token):
         scope = "playlist-modify-private"
@@ -405,7 +406,7 @@ class SpotifyPKCECacheTest(unittest.TestCase):
 
     @patch.multiple(SpotifyPKCE,
                     is_token_expired=DEFAULT, refresh_access_token=DEFAULT)
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_badly_scoped_token_bails(self, opener,
                                       is_token_expired, refresh_access_token):
         token_scope = "playlist-modify-public"
@@ -423,7 +424,7 @@ class SpotifyPKCECacheTest(unittest.TestCase):
         self.assertIsNone(cached_tok)
         self.assertEqual(refresh_access_token.call_count, 0)
 
-    @patch('spotipy.oauth2.open', create=True)
+    @patch('spotipy.cache_handler.open', create=True)
     def test_saves_to_cache_path(self, opener):
         scope = "playlist-modify-private"
         path = ".cache-username"


### PR DESCRIPTION
## Contributing.md Checklist:

- [X] Tests pass
- [X] Autopep8 fixing performed
- [X] flake8 verification passes
- [ ] isort: raises issues, but issues appear unrelated to changes in pull request

## Change Description
Previous code only supported caching to and from json files in a given directory. In addition, the get_cached_token method mixed getting and getting the token in the same method.

This change creates a `CacheHandler` class to abstract out the caching implementation and allow the user to cache tokens in any way they see fit. For example, the user could create a `MongoCache` class to store and retrieve tokens from a Mongo database and specify that `cache_handler=MongoCache` when creating an `auth_manager` object.

`cache_handler` is added as an argument to `SpotifyOAuth`, `SpotifyPKCE`, and `SpotifyImplicitGrant`. Specifying a `cache_handler` now overrides any specification of `cache_path` and/or `username`.

To preserve backwards compatibility in handling cache files, a `CacheFileHandler` class extending `CacheHandler` is created that implements previous functionality in getting and saving to json files. If no `cache_handler` is specified, the `cache_path` and `username` arguments are used to create an instance of `CacheFileHandler`. It may be worth deprecating the `cache_path` and `username` fields in favour of using `CacheFileHandler` to simplify the interface.

Tests are also modified and extended to cover the new functionality. A sample `MemoryCache` `CacheHandler` that stores the cached token as a variable in memory is created to test getting and saving to a custom `CacheHandler`.

Minor refactoring of `is_token_expired` and `_is_scope_subset` also performed to make adding the `CacheHandler` abstraction easier. 