### PR TITLE
Fix Spotify.user_playlist_reorder_items parameter order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support `market` optional parameter in `track`
 - Added CacheHandler abstraction to allow users to cache tokens in any way they see fit
 
+### Fixed
+
+- Fixed Spotify.user_playlist_reorder_tracks calling Spotify.playlist_reorder_tracks with an incorrect parameter order
+
 ## [2.16.1] - 2020-10-24
 
 ### Fixed

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -874,7 +874,7 @@ class Spotify(object):
             DeprecationWarning,
         )
         return self.playlist_reorder_items(playlist_id, range_start,
-                                           range_length, insert_before,
+                                           insert_before, range_length,
                                            snapshot_id)
 
     def user_playlist_remove_all_occurrences_of_tracks(


### PR DESCRIPTION
Spotify.user_playlist_reorder_items currently calls Spotify.playlist_reorder_items with the parameters in the incorrect order. Not a big deal since this is deprecated but nice for legacy projects.