### PR TITLE
docs: fix simple typo, retrival -> retrieval

### DIFF
--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -1113,7 +1113,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         redirect_host, redirect_port = get_host_port(redirect_info.netloc)
         # Implicit Grant tokens are returned in a hash fragment
         # which is only available to the browser. Therefore, interactive
-        # URL retrival is required.
+        # URL retrieval is required.
         if (redirect_host in ("127.0.0.1", "localhost")
                 and redirect_info.scheme == "http" and redirect_port):
             logger.warning('Using a local redirect URI with a '


### PR DESCRIPTION
There is a small typo in spotipy/oauth2.py.

Should read `retrieval` rather than `retrival`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md