### PR TITLE
get port from SPOTIPY_REDIRECT_URI rather than having to specify it 

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -18,12 +18,13 @@ Prerequisites
 
 Run app.py
 
-    python3 -m flask run --port=8080
+    python3 app.py OR python3 -m flask run
     NOTE: If receiving "port already in use" error, try other ports: 5000, 8090, 8888, etc...
         (will need to be updated in your Spotify app and SPOTIPY_REDIRECT_URI variable)
 """
 
 import os
+import re
 from flask import Flask, session, request, redirect
 from flask_session import Session
 import spotipy
@@ -123,4 +124,4 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-	app.run(threaded=True, port=int(os.environ.get("PORT", 8080)))
+	app.run(threaded=True, port=int((re.findall("^\d+$|(?<=:)\d+", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0]))


### PR DESCRIPTION
for convenience sake we pull the port directly from  SPOTIPY_REDIRECT_URI , as we have to specify it there anyway.
No need to either specify --port inline or FLASK_RUN_PORT envar anymore.