### PR TITLE
Removed requirement for examples/app.py to specify port multiple times (only SPOTIPY_REDIRECT_URI needs to contain the port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed docs for `search` to mention that you can provide multiple types to search for
 - The query parameters of requests are now logged
 - Deprecate specifing `cache_path` or `username` directly to `SpotifyOAuth`, `SpotifyPKCE`, and `SpotifyImplicitGrant` constructors, instead directing users to use the `CacheFileHandler` cache handler
-- Removed requirement for examples/app.py to specify port multiple times (only SPOTIPY_REDIRECT_URI needs to contain the port
+- Removed requirement for examples/app.py to specify port multiple times (only SPOTIPY_REDIRECT_URI needs to contain the port)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed docs for `search` to mention that you can provide multiple types to search for
 - The query parameters of requests are now logged
 - Deprecate specifing `cache_path` or `username` directly to `SpotifyOAuth`, `SpotifyPKCE`, and `SpotifyImplicitGrant` constructors, instead directing users to use the `CacheFileHandler` cache handler
+- Removed requirement for examples/app.py to specify port multiple times (only SPOTIPY_REDIRECT_URI needs to contain the port
 
 ### Added
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -124,5 +124,5 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-	    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+$", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
+    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+$", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -124,5 +124,7 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+$", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
-
+    app.run(threaded=True, port=int(os.environ.get("PORT", int(
+        os.environ.get("SPOTIPY_REDIRECT_URI").split(":")[-1]) if os.environ.get("SPOTIPY_REDIRECT_URI") is not None and
+                                                                  os.environ.get("SPOTIPY_REDIRECT_URI").split(":")[
+                                                                      -1] is not None else 8080)))

--- a/examples/app.py
+++ b/examples/app.py
@@ -124,5 +124,5 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-	    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
+	    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+$", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -123,7 +123,5 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-    app.run(threaded=True, port=int(os.environ.get("PORT", int(
-        os.environ.get("SPOTIPY_REDIRECT_URI").split(":")[-1]) if os.environ.get("SPOTIPY_REDIRECT_URI") is not None and
-                                                                  os.environ.get("SPOTIPY_REDIRECT_URI").split(":")[
-                                                                      -1] is not None else 8080)))
+    app.run(threaded=True, port=int(os.environ.get("PORT",
+                                                   os.environ.get("SPOTIPY_REDIRECT_URI", 8080).split(":")[-1])))

--- a/examples/app.py
+++ b/examples/app.py
@@ -24,7 +24,6 @@ Run app.py
 """
 
 import os
-import re
 from flask import Flask, session, request, redirect
 from flask_session import Session
 import spotipy

--- a/examples/app.py
+++ b/examples/app.py
@@ -124,4 +124,5 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-	app.run(threaded=True, port=int((re.findall("^\d+$|(?<=:)\d+", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0]))
+	    app.run(threaded=True, port=int(os.environ.get("PORT", (re.findall("^\d+$|(?<=:)\d+", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0])))
+

--- a/examples/app.py
+++ b/examples/app.py
@@ -18,12 +18,13 @@ Prerequisites
 
 Run app.py
 
-    python3 -m flask run --port=8080
+    python3 app.py OR python3 -m flask run
     NOTE: If receiving "port already in use" error, try other ports: 5000, 8090, 8888, etc...
         (will need to be updated in your Spotify app and SPOTIPY_REDIRECT_URI variable)
 """
 
 import os
+import re
 from flask import Flask, session, request, redirect
 from flask_session import Session
 import spotipy
@@ -123,4 +124,4 @@ Following lines allow application to be run more conveniently with
 (Also includes directive to leverage pythons threading capacity.)
 '''
 if __name__ == '__main__':
-	app.run(threaded=True, port=int(os.environ.get("PORT", 8080)))
+	app.run(threaded=True, port=int((re.findall("^\d+$|(?<=:)\d+", os.environ.get("SPOTIPY_REDIRECT_URI", 8080)))[0]))


### PR DESCRIPTION
we try to get the port from SPOTIPY_REDIRECT_URI as we already have to set it there anyway.
if we don't succeed we use 8080 as fallback.
for legacy compatibility we still allow PORT envar and let it override the setting 