### PR TITLE
Replace Urllib3 method_whitelist with allowed_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Spotify.user_playlist_reorder_tracks calling Spotify.playlist_reorder_tracks with an incorrect parameter order
+- Fixed deprecated Urllib3 `Retry(method_whitelist=...)` in favor of `Retry(allowed_methods=...)`
 
 ## [2.16.1] - 2020-10-24
 

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     author_email="paul@echonest.com",
     url='https://spotipy.readthedocs.org/',
     install_requires=[
-        'requests>=2.20.0',
-        'six>=1.10.0',
+        'requests>=2.25.0',
+        'six>=1.15.0',
     ],
     tests_require=test_reqs,
     extras_require=extra_reqs,

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -194,7 +194,7 @@ class Spotify(object):
             total=self.retries,
             connect=None,
             read=False,
-            method_whitelist=frozenset(['GET', 'POST', 'PUT', 'DELETE']),
+            allowed_methods=frozenset(['GET', 'POST', 'PUT', 'DELETE']),
             status=self.status_retries,
             backoff_factor=self.backoff_factor,
             status_forcelist=self.status_forcelist)


### PR DESCRIPTION
This is a proposed fix for #637 

Since Urllib3 v1.26.0 method_whitelist is deprecated and replaced with allowed_methods.