### PR TITLE
Make return structure for "Get Multiple..." type APIs consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+ - Unwrapped single-entry dictionaries returned by client.py functions whose corresponding API returns a JSON object with a single entry. Currently, some functions like `audio_features` already do this but others don't. This change conforms them all to unwrapping. Affected functions include those wrapping the following APIs:
+   - [Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
+   - [Get Multiple Artists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
+   - [Get an Artist's Top Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artists-top-tracks)
+   - [Get an Artist's Related ARtists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-artists-related-artists)
+   - [Get Multiple Albums](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
+   - [Get Multiple Shows](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-shows)
+   - [Get Multiple Episodes](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-episodes)
+   - [Get Recommendation Genres](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-recommendation-genres)
+   - [Get Audio Features for Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features)
+   - [Get a User's Available Devices](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-users-available-devices)
 
 ## Unreleased
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -452,7 +452,7 @@ class Spotify(object):
         """
 
         tlist = [self._get_id("album", a) for a in albums]
-        results self._get("albums/?ids=" + ",".join(tlist))
+        results = self._get("albums/?ids=" + ",".join(tlist))
         return results["albums"] if "albums" in results else results
 
     def show(self, show_id, market=None):
@@ -1609,7 +1609,7 @@ class Spotify(object):
     def recommendation_genre_seeds(self):
         """ Get a list of genres available for the recommendations function.
         """
-        result = self._get("recommendations/available-genre-seeds")
+        results = self._get("recommendations/available-genre-seeds")
         return results["genres"] if "genres" in results else results
 
     def audio_analysis(self, track_id):

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -95,8 +95,7 @@ class AuthTestSpotipy(unittest.TestCase):
 
     def test_artists(self):
         results = self.spotify.artists([self.weezer_urn, self.radiohead_urn])
-        self.assertTrue('artists' in results)
-        self.assertTrue(len(results['artists']) == 2)
+        self.assertTrue(len(results) == 2)
 
     def test_album_urn(self):
         album = self.spotify.album(self.pinkerton_urn)
@@ -121,8 +120,7 @@ class AuthTestSpotipy(unittest.TestCase):
     def test_albums(self):
         results = self.spotify.albums(
             [self.pinkerton_urn, self.pablo_honey_urn])
-        self.assertTrue('albums' in results)
-        self.assertTrue(len(results['albums']) == 2)
+        self.assertTrue(len(results) == 2)
 
     def test_track_urn(self):
         track = self.spotify.track(self.creep_urn)
@@ -146,19 +144,16 @@ class AuthTestSpotipy(unittest.TestCase):
 
     def test_tracks(self):
         results = self.spotify.tracks([self.creep_url, self.el_scorcho_urn])
-        self.assertTrue('tracks' in results)
-        self.assertTrue(len(results['tracks']) == 2)
+        self.assertTrue(len(results) == 2)
 
     def test_artist_top_tracks(self):
         results = self.spotify.artist_top_tracks(self.weezer_urn)
-        self.assertTrue('tracks' in results)
-        self.assertTrue(len(results['tracks']) == 10)
+        self.assertTrue(len(results) == 10)
 
     def test_artist_related_artists(self):
         results = self.spotify.artist_related_artists(self.weezer_urn)
-        self.assertTrue('artists' in results)
-        self.assertTrue(len(results['artists']) == 20)
-        for artist in results['artists']:
+        self.assertTrue(len(results) == 20)
+        for artist in results:
             if artist['name'] == 'Jimmy Eat World':
                 found = True
         self.assertTrue(found)
@@ -297,8 +292,7 @@ class AuthTestSpotipy(unittest.TestCase):
 
     def test_shows(self):
         results = self.spotify.shows([self.heavyweight_urn, self.reply_all_urn], market="US")
-        self.assertTrue('shows' in results)
-        self.assertTrue(len(results['shows']) == 2)
+        self.assertTrue(len(results) == 2)
 
     def test_show_episodes(self):
         results = self.spotify.show_episodes(self.heavyweight_urn, market="US")
@@ -337,8 +331,7 @@ class AuthTestSpotipy(unittest.TestCase):
             [self.heavyweight_ep1_urn, self.reply_all_ep1_urn],
             market="US"
         )
-        self.assertTrue('episodes' in results)
-        self.assertTrue(len(results['episodes']) == 2)
+        self.assertTrue(len(results) == 2)
 
     def test_unauthenticated_post_fails(self):
         with self.assertRaises(SpotifyException) as cm:

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -426,7 +426,7 @@ class SpotipyPlayerApiTests(unittest.TestCase):
     def test_devices(self):
         # No devices playing by default
         res = self.spotify.devices()
-        self.assertEqual(len(res["devices"]), 0)
+        self.assertEqual(len(res), 0)
 
     def test_current_user_recently_played(self):
         # No cursor


### PR DESCRIPTION
Get-Multiple APIs have a JSON response structure of with a single entry whose value is a list containing the actual requested items as dictionaries. The audio_features function in client.py was adapted to unwrap the single value in commit 9c0b872e86db479b1ba38a826a7f1f77fa3d68b8, but other functions for similar APIs (eg. tracks, artists, albums, ...) have not been adapted, leading to an inconsistent structure in the returned dictionary. This change modifies those functions to handle the response similar to audio_features.