### PR TITLE
Fixed audio_features API wrapper function return structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+Modified the return structure of the `audio_features` function (wrapping the [Get Audio Features for Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features) API) to conform to the return structure of similar APIs, such as:
+ - [Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
+ - [Get Multiple Artists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
+ - [Get Multiple Albums](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
+The functions wrapping these APIs do not unwrap the single key JSON response, and this is currently the only function that does this.
+
 
 ## Unreleased
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1623,12 +1623,7 @@ class Spotify(object):
         else:
             tlist = [self._get_id("track", t) for t in tracks]
             results = self._get("audio-features/?ids=" + ",".join(tlist))
-        # the response has changed, look for the new style first, and if
-        # its not there, fallback on the old style
-        if "audio_features" in results:
-            return results["audio_features"]
-        else:
-            return results
+        return results
 
     def devices(self):
         """ Get a list of user's available devices.

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -67,19 +67,19 @@ class AuthTestSpotipy(unittest.TestCase):
 
     def test_audio_features(self):
         results = self.spotify.audio_features(self.four_tracks)
-        self.assertTrue(len(results) == len(self.four_tracks))
-        for track in results:
+        self.assertTrue(len(results['audio_features']) == len(self.four_tracks))
+        for track in results['audio_features']:
             assert('speechiness' in track)
 
     def test_audio_features_with_bad_track(self):
         bad_tracks = ['spotify:track:bad']
         input = self.four_tracks + bad_tracks
         results = self.spotify.audio_features(input)
-        self.assertTrue(len(results) == len(input))
-        for track in results[:-1]:
+        self.assertTrue(len(results['audio_features']) == len(input))
+        for track in results['audio_features'][:-1]:
             if track is not None:
                 assert('speechiness' in track)
-        self.assertTrue(results[-1] is None)
+        self.assertTrue(results['audio_features'][-1] is None)
 
     def test_recommendations(self):
         results = self.spotify.recommendations(


### PR DESCRIPTION
Currently the function wrapping the `audio_features` (querying the audio features for multiple tracks) unwraps the single-entry of the JSON object returned by the Spotify API endpoint it wraps. Currently, other functions similar endpoints, querying multiple tracks, artists, albums, etc, do not unwrap the JSON response. This change aims to conform the audio_features function's return type. See [this comment](https://github.com/plamere/spotipy/pull/651#issuecomment-790932982) from a similar pull request for context.