### PR TITLE
Added cache handler to `SpotifyClientCredentials` and fixed a bug in refresh tokens methods that raised the wrong exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## Unreleased
 
 ### Added
+
 - Enabled using both short and long IDs for playlist_change_details
+- Added a cache handler to `SpotifyClientCredentials`
 
 ### Changed
+
 - Add support for a list of scopes rather than just a comma separated string of scopes
+
+### Fixed
+
+* Fixed the bugs in `SpotifyOAuth.refresh_access_token` and `SpotifyPKCE.refresh_access_token` which raised the incorrect exception upon receiving an error response from the server. This addresses #645.
+
+* Fixed a bug in `RequestHandler.do_GET` in which the non-existent `state` attribute of  `SpotifyOauthError` is accessed. This bug occurs when the user clicks "cancel" in the permissions dialog that opens in the browser.
+
+* Cleaned up the documentation for `SpotifyClientCredentials.__init__`, `SpotifyOAuth.__init__`, and `SpotifyPKCE.__init__`.
+
+    
 
 ## [2.17.1] - 2021-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - moved os.remove(session_cache_path()) inside try block to avoid TypeError on app.py example file
 - A warning will no longer be emitted when the cache file does not exist at the specified path
 - The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"
-- Changed docs for `search` to mention that you can provide multiple multiple types to search for
+- Changed docs for `search` to mention that you can provide multiple types to search for
 - The query parameters of requests are now logged
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - moved os.remove(session_cache_path()) inside try block to avoid TypeError on app.py example file
 - A warning will no longer be emitted when the cache file does not exist at the specified path
-- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"
+- Changed docs for `search` to mention that you can provide multiple multiple types to search for
+- The query parameters of requests are now logged
+
+### Added
+
+- Added log messages for when the access token and refresh tokens are retrieved and when they are refreshed
+
+    
 
 ## [2.16.1] - 2020-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+- A warning will no longer be emitted when the cache file does not exist at the specified path
+- The docs for the `auth` parameter of `Spotify.init` use the term "access token" instead of "authorization token"  
 
 ## [2.16.1] - 2020-10-24
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -233,8 +233,8 @@ class Spotify(object):
         if self.language is not None:
             headers["Accept-Language"] = self.language
 
-        logger.debug('Sending %s to %s with Headers: %s and Body: %r ',
-                     method, url, headers, args.get('data'))
+        logger.debug('Sending %s to %s with Params: %s Headers: %s and Body: %r ',
+                     method, url, args.get("params"), headers, args.get('data'))
 
         try:
             response = self._session.request(
@@ -534,10 +534,12 @@ class Spotify(object):
             Parameters:
                 - q - the search query (see how to write a query in the
                       official documentation https://developer.spotify.com/documentation/web-api/reference/search/search/)  # noqa
-                - limit  - the number of items to return (min = 1, default = 10, max = 50)
+                - limit - the number of items to return (min = 1, default = 10, max = 50). The limit is applied
+                          within each type, not on the total response.
                 - offset - the index of the first item to return
-                - type - the type of item to return. One of 'artist', 'album',
-                         'track', 'playlist', 'show', or 'episode'
+                - type - the types of items to return. One or more of 'artist', 'album',
+                         'track', 'playlist', 'show', and 'episode'.  If multiple types are desired,
+                         pass in a comma separated string; e.g., 'track,album,episode'.
                 - market - An ISO 3166-1 alpha-2 country code or the string
                            from_token.
         """
@@ -554,8 +556,8 @@ class Spotify(object):
                 - limit  - the number of items to return (min = 1, default = 10, max = 50). If a search is to be done on multiple
                             markets, then this limit is applied to each market. (e.g. search US, CA, MX each with a limit of 10).
                 - offset - the index of the first item to return
-                - type - the type's of item's to return. One or more of 'artist', 'album',
-                         'track', 'playlist', 'show', or 'episode'. If multiple types are desired, pass in a comma separated list.
+                - type - the types of items to return. One or more of 'artist', 'album',
+                         'track', 'playlist', 'show', or 'episode'. If multiple types are desired, pass in a comma separated string.
                 - markets - A list of ISO 3166-1 alpha-2 country codes. Search all country markets by default.
                 - total - the total number of results to return if multiple markets are supplied in the search.
                           If multiple types are specified, this only applies to the first type.

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -114,7 +114,7 @@ class Spotify(object):
         """
         Creates a Spotify API client.
 
-        :param auth: An authorization token (optional)
+        :param auth: An access token (optional)
         :param requests_session:
             A Requests session object or a truthy value to create one.
             A falsy value disables sessions.

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -289,27 +289,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +770,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                token_info = self.refresh_access_token(
-                    token_info["refresh_token"]
-                )
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    token_info = self.refresh_access_token(
+                        token_info["refresh_token"]
+                    )
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1019,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        try:
-            f = open(self.cache_path)
-            token_info_string = f.read()
-            f.close()
-            token_info = json.loads(token_info_string)
+        if os.path.exists(self.cache_path):
+            try:
+                f = open(self.cache_path)
+                token_info_string = f.read()
+                f.close()
+                token_info = json.loads(token_info_string)
 
-            # if scopes don't match, then bail
-            if "scope" not in token_info or not self._is_scope_subset(
-                    self.scope, token_info["scope"]
-            ):
-                return None
+                # if scopes don't match, then bail
+                if "scope" not in token_info or not self._is_scope_subset(
+                        self.scope, token_info["scope"]
+                ):
+                    return None
 
-            if self.is_token_expired(token_info):
-                return None
-
-        except FileNotFoundError:
+                if self.is_token_expired(token_info):
+                    return None
+            except IOError:
+                logger.warning("Couldn't read cache at: %s", self.cache_path)
+        else:
             logger.debug("cache does not exist at: %s", self.cache_path)
-        except IOError:
-            logger.warning("Couldn't read cache at: %s", self.cache_path)
 
         return token_info
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -197,6 +197,11 @@ class SpotifyClientCredentials(SpotifyAuthBase):
             self.client_id, self.client_secret
         )
 
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
+
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
             data=payload,
@@ -494,6 +499,11 @@ class SpotifyOAuth(SpotifyAuthBase):
 
         headers = self._make_authorization_headers()
 
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
+
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
             data=payload,
@@ -528,6 +538,11 @@ class SpotifyOAuth(SpotifyAuthBase):
         }
 
         headers = self._make_authorization_headers()
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
@@ -836,8 +851,8 @@ class SpotifyPKCE(SpotifyAuthBase):
 
             Parameters:
                 - code - the response code from authentication
-                - check_cache - if true, checks for locally stored token
-                                before requesting a new token if True
+                - check_cache - if true, checks for a locally stored token
+                                before requesting a new token
         """
 
         if check_cache:
@@ -861,6 +876,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,
@@ -891,6 +911,11 @@ class SpotifyPKCE(SpotifyAuthBase):
         }
 
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
+        logger.debug(
+            "sending POST request to %s with Headers: %s and Body: %r",
+            self.OAUTH_TOKEN_URL, headers, payload
+        )
 
         response = self._session.post(
             self.OAUTH_TOKEN_URL,

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -306,6 +306,8 @@ class SpotifyOAuth(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -785,6 +787,8 @@ class SpotifyPKCE(SpotifyAuthBase):
                     token_info["refresh_token"]
                 )
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 
@@ -1030,6 +1034,8 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
             if self.is_token_expired(token_info):
                 return None
 
+        except FileNotFoundError:
+            logger.debug("cache does not exist at: %s", self.cache_path)
         except IOError:
             logger.warning("Couldn't read cache at: %s", self.cache_path)
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -11,6 +11,7 @@ __all__ = [
 ]
 
 import base64
+import errno
 import json
 import logging
 import os
@@ -289,27 +290,27 @@ class SpotifyOAuth(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -770,27 +771,27 @@ class SpotifyPKCE(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    token_info = self.refresh_access_token(
-                        token_info["refresh_token"]
-                    )
-            except IOError:
+            if self.is_token_expired(token_info):
+                token_info = self.refresh_access_token(
+                    token_info["refresh_token"]
+                )
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 
@@ -1019,25 +1020,25 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         """
         token_info = None
 
-        if os.path.exists(self.cache_path):
-            try:
-                f = open(self.cache_path)
-                token_info_string = f.read()
-                f.close()
-                token_info = json.loads(token_info_string)
+        try:
+            f = open(self.cache_path)
+            token_info_string = f.read()
+            f.close()
+            token_info = json.loads(token_info_string)
 
-                # if scopes don't match, then bail
-                if "scope" not in token_info or not self._is_scope_subset(
-                        self.scope, token_info["scope"]
-                ):
-                    return None
+            # if scopes don't match, then bail
+            if "scope" not in token_info or not self._is_scope_subset(
+                    self.scope, token_info["scope"]
+            ):
+                return None
 
-                if self.is_token_expired(token_info):
-                    return None
-            except IOError:
+            if self.is_token_expired(token_info):
+                return None
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                logger.debug("cache does not exist at: %s", self.cache_path)
+            else:
                 logger.warning("Couldn't read cache at: %s", self.cache_path)
-        else:
-            logger.debug("cache does not exist at: %s", self.cache_path)
 
         return token_info
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -24,7 +24,6 @@ from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 from six.moves.urllib_parse import parse_qsl, urlparse
 
 from spotipy.cache_handler import CacheFileHandler, CacheHandler
-from spotipy.exceptions import SpotifyException
 from spotipy.util import CLIENT_CREDS_ENV_VARS, get_host_port, normalize_scope
 
 logger = logging.getLogger(__name__)

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -139,27 +139,57 @@ class SpotifyAuthBase(object):
 class SpotifyClientCredentials(SpotifyAuthBase):
     OAUTH_TOKEN_URL = "https://accounts.spotify.com/api/token"
 
-    def __init__(self,
-                 client_id=None,
-                 client_secret=None,
-                 proxies=None,
-                 requests_session=True,
-                 requests_timeout=None):
+    def __init__(
+        self,
+        client_id=None,
+        client_secret=None,
+        proxies=None,
+        requests_session=True,
+        requests_timeout=None,
+        cache_handler=None
+    ):
         """
+        Creates a Client Credentials Flow Manager.
+
+        The Client Credentials flow is used in server-to-server authentication.
+        Only endpoints that do not access user information can be accessed.
+        This means that endpoints that require authorization scopes cannot be accessed.
+        The advantage, however, of this authorization flow is that it does not require any
+        user interaction
+
         You can either provide a client_id and client_secret to the
         constructor or set SPOTIPY_CLIENT_ID and SPOTIPY_CLIENT_SECRET
         environment variables
+
+        Parameters:
+             * client_id: Must be supplied or set as environment variable
+             * client_secret: Must be supplied or set as environment variable
+             * proxies: Optional, proxy for the requests library to route through
+             * requests_session: A Requests session
+             * requests_timeout: Optional, tell Requests to stop waiting for a response after
+                                 a given number of seconds
+             * cache_handler: An instance of the `CacheHandler` class to handle
+                              getting and saving cached authorization tokens.
+                              Optional, will otherwise use `CacheFileHandler`.
+                              (takes precedence over `cache_path` and `username`)
+
         """
 
         super(SpotifyClientCredentials, self).__init__(requests_session)
 
         self.client_id = client_id
         self.client_secret = client_secret
-        self.token_info = None
         self.proxies = proxies
         self.requests_timeout = requests_timeout
+        if cache_handler:
+            assert issubclass(cache_handler.__class__, CacheHandler), \
+                "cache_handler must be a subclass of CacheHandler: " + str(type(cache_handler)) \
+                + " != " + str(CacheHandler)
+            self.cache_handler = cache_handler
+        else:
+            self.cache_handler = CacheFileHandler()
 
-    def get_access_token(self, as_dict=True):
+    def get_access_token(self, as_dict=True, check_cache=True):
         """
         If a valid access token is in memory, returns it
         Else feches a new token and returns it
@@ -179,13 +209,15 @@ class SpotifyClientCredentials(SpotifyAuthBase):
                 stacklevel=2,
             )
 
-        if self.token_info and not self.is_token_expired(self.token_info):
-            return self.token_info if as_dict else self.token_info["access_token"]
+        if check_cache:
+            token_info = self.cache_handler.get_cached_token()
+            if token_info and not self.is_token_expired(token_info):
+                return token_info if as_dict else token_info["access_token"]
 
         token_info = self._request_access_token()
         token_info = self._add_custom_values_to_token_info(token_info)
-        self.token_info = token_info
-        return self.token_info["access_token"]
+        self.cache_handler.save_token_to_cache(token_info)
+        return token_info if as_dict else token_info["access_token"]
 
     def _request_access_token(self):
         """Gets client credentials access token """
@@ -260,20 +292,21 @@ class SpotifyOAuth(SpotifyAuthBase):
              * state: Optional, no verification is performed
              * scope: Optional, either a list of scopes or comma separated string of scopes.
                       e.g, "playlist-read-private,playlist-read-collaborative"
-             * cache_handler: An instance of the `CacheHandler` class to handle
-                              getting and saving cached authorization tokens.
-                              Optional, will otherwise use `CacheFileHandler`.
-                              (takes precedence over `cache_path` and `username`)
              * cache_path: (deprecated) Optional, will otherwise be generated
                            (takes precedence over `username`)
              * username: (deprecated) Optional or set as environment variable
                          (will set `cache_path` to `.cache-{username}`)
-             * show_dialog: Optional, interpreted as boolean
              * proxies: Optional, proxy for the requests library to route through
+             * show_dialog: Optional, interpreted as boolean
+             * requests_session: A Requests session
              * requests_timeout: Optional, tell Requests to stop waiting for a response after
                                  a given number of seconds
              * open_browser: Optional, whether or not the web browser should be opened to
                              authorize a user
+             * cache_handler: An instance of the `CacheHandler` class to handle
+                              getting and saving cached authorization tokens.
+                              Optional, will otherwise use `CacheFileHandler`.
+                              (takes precedence over `cache_path` and `username`)
         """
 
         super(SpotifyOAuth, self).__init__(requests_session)
@@ -414,7 +447,7 @@ class SpotifyOAuth(SpotifyAuthBase):
         if server.auth_code is not None:
             return server.auth_code
         elif server.error is not None:
-            raise SpotifyOauthError("Received error from OAuth server: {}".format(server.error))
+            raise server.error
         else:
             raise SpotifyOauthError("Server listening on localhost has not been accessed")
 
@@ -432,7 +465,7 @@ class SpotifyOAuth(SpotifyAuthBase):
             open_browser = self.open_browser
 
         if (
-                (open_browser or self.open_browser)
+                open_browser
                 and redirect_host in ("127.0.0.1", "localhost")
                 and redirect_info.scheme == "http"
         ):
@@ -539,20 +572,13 @@ class SpotifyOAuth(SpotifyAuthBase):
             timeout=self.requests_timeout,
         )
 
-        try:
-            response.raise_for_status()
-        except BaseException:
-            logger.error('Couldn\'t refresh token. Response Status Code: %s '
-                         'Reason: %s', response.status_code, response.reason)
-
-            message = "Couldn't refresh token: code:%d reason:%s" % (
-                response.status_code,
-                response.reason,
-            )
-            raise SpotifyException(response.status_code,
-                                   -1,
-                                   message,
-                                   headers)
+        if response.status_code != 200:
+            error_payload = response.json()
+            raise SpotifyOauthError(
+                'error: {0}, error_description: {1}'.format(
+                    error_payload['error'], error_payload['error_description']),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
 
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
@@ -623,25 +649,24 @@ class SpotifyPKCE(SpotifyAuthBase):
 
         Parameters:
              * client_id: Must be supplied or set as environment variable
-             * client_secret: Must be supplied or set as environment variable
              * redirect_uri: Must be supplied or set as environment variable
              * state: Optional, no verification is performed
              * scope: Optional, either a list of scopes or comma separated string of scopes.
                       e.g, "playlist-read-private,playlist-read-collaborative"
-             * cache_handler: An instance of the `CacheHandler` class to handle
-                              getting and saving cached authorization tokens.
-                              Optional, will otherwise use `CacheFileHandler`.
-                              (takes precedence over `cache_path` and `username`)
              * cache_path: (deprecated) Optional, will otherwise be generated
                            (takes precedence over `username`)
              * username: (deprecated) Optional or set as environment variable
                          (will set `cache_path` to `.cache-{username}`)
-             * show_dialog: Optional, interpreted as boolean
              * proxies: Optional, proxy for the requests library to route through
              * requests_timeout: Optional, tell Requests to stop waiting for a response after
                                  a given number of seconds
+             * requests_session: A Requests session
              * open_browser: Optional, thether or not the web browser should be opened to
                              authorize a user
+             * cache_handler: An instance of the `CacheHandler` class to handle
+                              getting and saving cached authorization tokens.
+                              Optional, will otherwise use `CacheFileHandler`.
+                              (takes precedence over `cache_path` and `username`)
         """
 
         super(SpotifyPKCE, self).__init__(requests_session)
@@ -921,20 +946,13 @@ class SpotifyPKCE(SpotifyAuthBase):
             timeout=self.requests_timeout,
         )
 
-        try:
-            response.raise_for_status()
-        except BaseException:
-            logger.error('Couldn\'t refresh token. Response Status Code: %s '
-                         'Reason: %s', response.status_code, response.reason)
-
-            message = "Couldn't refresh token: code:%d reason:%s" % (
-                response.status_code,
-                response.reason,
-            )
-            raise SpotifyException(response.status_code,
-                                   -1,
-                                   message,
-                                   headers)
+        if response.status_code != 200:
+            error_payload = response.json()
+            raise SpotifyOauthError(
+                'error: {0}, error_description: {1}'.format(
+                    error_payload['error'], error_payload['error_description']),
+                error=error_payload['error'],
+                error_description=error_payload['error_description'])
 
         token_info = response.json()
         token_info = self._add_custom_values_to_token_info(token_info)
@@ -1246,9 +1264,8 @@ class RequestHandler(BaseHTTPRequestHandler):
             state, auth_code = SpotifyOAuth.parse_auth_response_url(self.path)
             self.server.state = state
             self.server.auth_code = auth_code
-        except SpotifyOauthError as err:
-            self.server.state = err.state
-            self.server.error = err.error
+        except SpotifyOauthError as error:
+            self.server.error = error
 
         self.send_response(200)
         self.send_header("Content-Type", "text/html")


### PR DESCRIPTION
I see no reason why we shouldn't save the token info for the Client Credentials flow to persistent storage as well.

The methods for refreshing the access token now raise the proper exception . For example, instead of
```
spotipy.exceptions.SpotifyException: http status: 400, code:-1 - Couldn't refresh token: code:400 reason:Bad Request, reason: {'Authorization': 'Basic ZDEz...ZDc='}
```
you get
```
spotipy.oauth2.SpotifyOauthError: error: invalid_grant, error_description: Refresh token revoked
```
See #645