### PR TITLE
V3

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 While this is unreleased, please only add v3 features here.
 Rebasing master onto v3 doesn't require a changelog update.
 
-### Changed
-
-* Made `CacheHandler` an abstract base class
-
 ### Added
 
 * `Scope` - An enum which contains all of the authorization scopes (see [here](https://github.com/plamere/spotipy/issues/652#issuecomment-797461311)).
@@ -27,11 +23,12 @@ Rebasing master onto v3 doesn't require a changelog update.
 
 ### Changed
 
-Modified the return structure of the `audio_features` function (wrapping the [Get Audio Features for Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features) API) to conform to the return structure of similar APIs, such as:
- - [Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
- - [Get Multiple Artists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
- - [Get Multiple Albums](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
-The functions wrapping these APIs do not unwrap the single key JSON response, and this is currently the only function that does this.
+* Made `CacheHandler` an abstract base class
+
+* Modified the return structure of the `audio_features` function (wrapping the [Get Audio Features for Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features) API) to conform to the return structure of the similar methods listed below. The functions wrapping these APIs do not unwrap the single key JSON response, and this is currently the only function that does this.
+     * [Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
+     * [Get Multiple Artists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)
+     * [Get Multiple Albums](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-albums)
 
 ## Unreleased [2.x.x]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ While this is unreleased, please only add v3 features here.
 Rebasing master onto v3 doesn't require a changelog update.
 
 ### Changed
+
+* Made `CacheHandler` an abstract base class
+
+### Added
+
+* `Scope` - An enum which contains all of the authorization scopes (see [here](https://github.com/plamere/spotipy/issues/652#issuecomment-797461311)).
+
+* Added the following endpoints
+    * `Spotify.current_user_saved_episodes`
+    * `Spotify.current_user_saved_episodes_add`
+    * `Spotify.current_user_saved_episodes_delete`
+    * `Spotify.current_user_saved_episodes_contains`
+    * `Spotify.available_markets`
+
+### Changed
+
 Modified the return structure of the `audio_features` function (wrapping the [Get Audio Features for Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-audio-features) API) to conform to the return structure of similar APIs, such as:
  - [Get Several Tracks](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-several-tracks)
  - [Get Multiple Artists](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-multiple-artists)

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -3,3 +3,4 @@ from .client import *  # noqa
 from .exceptions import *  # noqa
 from .oauth2 import *  # noqa
 from .util import *  # noqa
+from .scope import *  # noqa

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -1,35 +1,36 @@
+# -*- coding: utf-8 -*-
+
 __all__ = ['CacheHandler', 'CacheFileHandler']
 
 import errno
 import json
 import logging
+from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 
 
-class CacheHandler():
+class CacheHandler(ABC):
     """
     An abstraction layer for handling the caching and retrieval of
     authorization tokens.
 
-    Custom extensions of this class must implement get_cached_token
-    and save_token_to_cache methods with the same input and output
-    structure as the CacheHandler class.
+    Clients are expected to subclass this class and override the
+    get_cached_token and save_token_to_cache methods with the same
+    type signatures of this class.
     """
 
+    @abstractmethod
     def get_cached_token(self):
         """
         Get and return a token_info dictionary object.
         """
-        # return token_info
-        raise NotImplementedError()
 
+    @abstractmethod
     def save_token_to_cache(self, token_info):
         """
         Save a token_info dictionary object to the cache and return None.
         """
-        raise NotImplementedError()
-        return None
 
 
 class CacheFileHandler(CacheHandler):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1190,10 +1190,7 @@ class Spotify(object):
                 - albums - a list of album URIs, URLs or IDs
         """
 
-        # print(f"default: {albums}")
-
         alist = [self._get_id("album", a) for a in albums]
-        print(f"alist: {alist}")
         return self._put("me/albums?ids=" + ",".join(alist))
 
     def current_user_saved_albums_delete(self, albums=[]):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1171,16 +1171,187 @@ class Spotify(object):
         """
         return self._get("me/player/currently-playing")
 
-    def current_user_saved_tracks(self, limit=20, offset=0):
+    def current_user_saved_albums(self, limit=20, offset=0, market=None):
+        """ Gets a list of the albums saved in the current authorized user's
+            "Your Music" library
+
+            Parameters:
+                - limit - the number of albums to return
+                - offset - the index of the first album to return
+                - market - an ISO 3166-1 alpha-2 country code.
+
+        """
+        return self._get("me/albums", limit=limit, offset=offset, market=market)
+
+    def current_user_saved_albums_add(self, albums=[]):
+        """ Add one or more albums to the current user's
+            "Your Music" library.
+            Parameters:
+                - albums - a list of album URIs, URLs or IDs
+        """
+
+        # print(f"default: {albums}")
+
+        alist = [self._get_id("album", a) for a in albums]
+        print(f"alist: {alist}")
+        return self._put("me/albums?ids=" + ",".join(alist))
+
+    def current_user_saved_albums_delete(self, albums=[]):
+        """ Remove one or more albums from the current user's
+            "Your Music" library.
+
+            Parameters:
+                - albums - a list of album URIs, URLs or IDs
+        """
+        alist = [self._get_id("album", a) for a in albums]
+        return self._delete("me/albums/?ids=" + ",".join(alist))
+
+    def current_user_saved_albums_contains(self, albums=[]):
+        """ Check if one or more albums is already saved in
+            the current Spotify user’s “Your Music” library.
+
+            Parameters:
+                - albums - a list of album URIs, URLs or IDs
+        """
+        alist = [self._get_id("album", a) for a in albums]
+        return self._get("me/albums/contains?ids=" + ",".join(alist))
+
+    def current_user_saved_tracks(self, limit=20, offset=0, market=None):
         """ Gets a list of the tracks saved in the current authorized user's
             "Your Music" library
 
             Parameters:
                 - limit - the number of tracks to return
                 - offset - the index of the first track to return
+                - market - an ISO 3166-1 alpha-2 country code
 
         """
-        return self._get("me/tracks", limit=limit, offset=offset)
+        return self._get("me/tracks", limit=limit, offset=offset, market=market)
+
+    def current_user_saved_tracks_add(self, tracks=None):
+        """ Add one or more tracks to the current user's
+            "Your Music" library.
+
+            Parameters:
+                - tracks - a list of track URIs, URLs or IDs
+        """
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id("track", t) for t in tracks]
+        return self._put("me/tracks/?ids=" + ",".join(tlist))
+
+    def current_user_saved_tracks_delete(self, tracks=None):
+        """ Remove one or more tracks from the current user's
+            "Your Music" library.
+
+            Parameters:
+                - tracks - a list of track URIs, URLs or IDs
+        """
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id("track", t) for t in tracks]
+        return self._delete("me/tracks/?ids=" + ",".join(tlist))
+
+    def current_user_saved_tracks_contains(self, tracks=None):
+        """ Check if one or more tracks is already saved in
+            the current Spotify user’s “Your Music” library.
+
+            Parameters:
+                - tracks - a list of track URIs, URLs or IDs
+        """
+        tlist = []
+        if tracks is not None:
+            tlist = [self._get_id("track", t) for t in tracks]
+        return self._get("me/tracks/contains?ids=" + ",".join(tlist))
+
+    def current_user_saved_episodes(self, limit=20, offset=0, market=None):
+        """ Gets a list of the episodes saved in the current authorized user's
+            "Your Music" library
+
+            Parameters:
+                - limit - the number of episodes to return
+                - offset - the index of the first episode to return
+                - market - an ISO 3166-1 alpha-2 country code
+
+        """
+        return self._get("me/episodes", limit=limit, offset=offset, market=market)
+
+    def current_user_saved_episodes_add(self, episodes=None):
+        """ Add one or more episodes to the current user's
+            "Your Music" library.
+
+            Parameters:
+                - episodes - a list of episode URIs, URLs or IDs
+        """
+        elist = []
+        if episodes is not None:
+            elist = [self._get_id("episode", e) for e in episodes]
+        return self._put("me/episodes/?ids=" + ",".join(elist))
+
+    def current_user_saved_episodes_delete(self, episodes=None):
+        """ Remove one or more episodes from the current user's
+            "Your Music" library.
+
+            Parameters:
+                - episodes - a list of episode URIs, URLs or IDs
+        """
+        elist = []
+        if episodes is not None:
+            elist = [self._get_id("episode", e) for e in episodes]
+        return self._delete("me/episodes/?ids=" + ",".join(elist))
+
+    def current_user_saved_episodes_contains(self, episodes=None):
+        """ Check if one or more episodes is already saved in
+            the current Spotify user’s “Your Music” library.
+
+            Parameters:
+                - episodes - a list of episode URIs, URLs or IDs
+        """
+        elist = []
+        if episodes is not None:
+            elist = [self._get_id("episode", e) for e in episodes]
+        return self._get("me/episodes/contains?ids=" + ",".join(elist))
+
+    def current_user_saved_shows(self, limit=20, offset=0, market=None):
+        """ Gets a list of the shows saved in the current authorized user's
+            "Your Music" library
+
+            Parameters:
+                - limit - the number of shows to return
+                - offset - the index of the first show to return
+                - market - an ISO 3166-1 alpha-2 country code
+
+        """
+        return self._get("me/shows", limit=limit, offset=offset, market=market)
+
+    def current_user_saved_shows_add(self, shows=[]):
+        """ Add one or more albums to the current user's
+            "Your Music" library.
+            Parameters:
+                - shows - a list of show URIs, URLs or IDs
+        """
+        slist = [self._get_id("show", s) for s in shows]
+        return self._put("me/shows?ids=" + ",".join(slist))
+
+    def current_user_saved_shows_delete(self, shows=[]):
+        """ Remove one or more shows from the current user's
+            "Your Music" library.
+
+            Parameters:
+                - shows - a list of show URIs, URLs or IDs
+        """
+        slist = [self._get_id("show", s) for s in shows]
+        return self._delete("me/shows/?ids=" + ",".join(slist))
+
+    def current_user_saved_shows_contains(self, shows=[]):
+        """ Check if one or more shows is already saved in
+            the current Spotify user’s “Your Music” library.
+
+            Parameters:
+                - shows - a list of show URIs, URLs or IDs
+        """
+        slist = [self._get_id("show", s) for s in shows]
+        return self._get("me/shows/contains?ids=" + ",".join(slist))
 
     def current_user_followed_artists(self, limit=20, after=None):
         """ Gets a list of the artists followed by the current authorized user
@@ -1224,42 +1395,6 @@ class Spotify(object):
         return self._get(
             "me/following/contains", ids=",".join(idlist), type="user"
         )
-
-    def current_user_saved_tracks_delete(self, tracks=None):
-        """ Remove one or more tracks from the current user's
-            "Your Music" library.
-
-            Parameters:
-                - tracks - a list of track URIs, URLs or IDs
-        """
-        tlist = []
-        if tracks is not None:
-            tlist = [self._get_id("track", t) for t in tracks]
-        return self._delete("me/tracks/?ids=" + ",".join(tlist))
-
-    def current_user_saved_tracks_contains(self, tracks=None):
-        """ Check if one or more tracks is already saved in
-            the current Spotify user’s “Your Music” library.
-
-            Parameters:
-                - tracks - a list of track URIs, URLs or IDs
-        """
-        tlist = []
-        if tracks is not None:
-            tlist = [self._get_id("track", t) for t in tracks]
-        return self._get("me/tracks/contains?ids=" + ",".join(tlist))
-
-    def current_user_saved_tracks_add(self, tracks=None):
-        """ Add one or more tracks to the current user's
-            "Your Music" library.
-
-            Parameters:
-                - tracks - a list of track URIs, URLs or IDs
-        """
-        tlist = []
-        if tracks is not None:
-            tlist = [self._get_id("track", t) for t in tracks]
-        return self._put("me/tracks/?ids=" + ",".join(tlist))
 
     def current_user_top_artists(
         self, limit=20, offset=0, time_range="medium_term"
@@ -1309,86 +1444,6 @@ class Spotify(object):
             after=after,
             before=before,
         )
-
-    def current_user_saved_albums(self, limit=20, offset=0):
-        """ Gets a list of the albums saved in the current authorized user's
-            "Your Music" library
-
-            Parameters:
-                - limit - the number of albums to return
-                - offset - the index of the first album to return
-
-        """
-        return self._get("me/albums", limit=limit, offset=offset)
-
-    def current_user_saved_albums_contains(self, albums=[]):
-        """ Check if one or more albums is already saved in
-            the current Spotify user’s “Your Music” library.
-
-            Parameters:
-                - albums - a list of album URIs, URLs or IDs
-        """
-        alist = [self._get_id("album", a) for a in albums]
-        return self._get("me/albums/contains?ids=" + ",".join(alist))
-
-    def current_user_saved_albums_add(self, albums=[]):
-        """ Add one or more albums to the current user's
-            "Your Music" library.
-            Parameters:
-                - albums - a list of album URIs, URLs or IDs
-        """
-        alist = [self._get_id("album", a) for a in albums]
-        return self._put("me/albums?ids=" + ",".join(alist))
-
-    def current_user_saved_albums_delete(self, albums=[]):
-        """ Remove one or more albums from the current user's
-            "Your Music" library.
-
-            Parameters:
-                - albums - a list of album URIs, URLs or IDs
-        """
-        alist = [self._get_id("album", a) for a in albums]
-        return self._delete("me/albums/?ids=" + ",".join(alist))
-
-    def current_user_saved_shows(self, limit=50, offset=0):
-        """ Gets a list of the shows saved in the current authorized user's
-            "Your Music" library
-
-            Parameters:
-                - limit - the number of shows to return
-                - offset - the index of the first show to return
-
-        """
-        return self._get("me/shows", limit=limit, offset=offset)
-
-    def current_user_saved_shows_contains(self, shows=[]):
-        """ Check if one or more shows is already saved in
-            the current Spotify user’s “Your Music” library.
-
-            Parameters:
-                - shows - a list of show URIs, URLs or IDs
-        """
-        slist = [self._get_id("show", s) for s in shows]
-        return self._get("me/shows/contains?ids=" + ",".join(slist))
-
-    def current_user_saved_shows_add(self, shows=[]):
-        """ Add one or more albums to the current user's
-            "Your Music" library.
-            Parameters:
-                - shows - a list of show URIs, URLs or IDs
-        """
-        slist = [self._get_id("show", s) for s in shows]
-        return self._put("me/shows?ids=" + ",".join(slist))
-
-    def current_user_saved_shows_delete(self, shows=[]):
-        """ Remove one or more shows from the current user's
-            "Your Music" library.
-
-            Parameters:
-                - shows - a list of show URIs, URLs or IDs
-        """
-        slist = [self._get_id("show", s) for s in shows]
-        return self._delete("me/shows/?ids=" + ",".join(slist))
 
     def user_follow_artists(self, ids=[]):
         """ Follow one or more artists
@@ -1823,6 +1878,14 @@ class Spotify(object):
             endpoint += "&device_id=%s" % device_id
 
         return self._post(endpoint)
+
+    def available_markets(self):
+        """ Get the list of markets where Spotify is available.
+
+            Returns a list of the countries in which Spotify is available, identified by their
+            ISO 3166-1 alpha-2 country code with additional country codes for special territories.
+        """
+        return self._get("markets")
 
     def _append_device_id(self, path, device_id):
         """ Append device ID to API path.

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -118,8 +118,8 @@ class SpotifyAuthBase(object):
             return None
 
         raise TypeError(
-            f"Unsupported type for scopes: {type(scope)}. Expected either a string of scopes, or "
-            "an Iterable with elements of type `Scope` or `str`."
+            "Unsupported type for scopes: %s. Expected either a string of scopes, or "
+            "an Iterable with elements of type `Scope` or `str`." % type(scope)
         )
 
     @property

--- a/spotipy/scope.py
+++ b/spotipy/scope.py
@@ -4,7 +4,7 @@ __all__ = ["Scope"]
 
 from enum import Enum
 import re
-from typing import Iterable
+from typing import Iterable, Set
 
 
 class Scope(Enum):
@@ -45,10 +45,10 @@ class Scope(Enum):
     user_modify_playback_state = "user-modify-playback-state"
 
     @staticmethod
-    def all() -> set['Scope']:
+    def all() -> Set['Scope']:
         """Returns all of the authorization scopes"""
 
-        return set(scope.value for scope in Scope)
+        return set(Scope)
 
     @staticmethod
     def make_string(scopes: Iterable['Scope']) -> str:
@@ -62,7 +62,7 @@ class Scope(Enum):
         return " ".join([scope.value for scope in scopes])
 
     @staticmethod
-    def from_string(scope_string: str) -> set['Scope']:
+    def from_string(scope_string: str) -> Set['Scope']:
         """
         Converts a string of (usuallly space-separated) scopes into a
         set of scopes

--- a/spotipy/scope.py
+++ b/spotipy/scope.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ["Scope"]
+
+from enum import Enum
+import re
+from typing import Iterable
+
+
+class Scope(Enum):
+    """
+    The Spotify authorization scopes
+
+    Create a Scope from a string:
+
+    scope = Scope("playlist-modify-private")
+
+    Create a set of scopes:
+
+    scopes = {
+        Scope.user_read_currently_playing,
+        Scope.playlist_read_collaborative,
+        Scope.playlist_modify_public
+    }
+    """
+
+    user_read_currently_playing = "user-read-currently-playing"
+    playlist_read_collaborative = "playlist-read-collaborative"
+    playlist_modify_private = "playlist-modify-private"
+    user_read_playback_position = "user-read-playback-position"
+    user_library_modify = "user-library-modify"
+    user_top_read = "user-top-read"
+    user_read_playback_state = "user-read-playback-state"
+    user_read_email = "user-read-email"
+    ugc_image_upload = "ugc-image-upload"
+    user_read_private = "user-read-private"
+    playlist_modify_public = "playlist-modify-public"
+    user_library_read = "user-library-read"
+    streaming = "streaming"
+    user_read_recently_played = "user-read-recently-played"
+    user_follow_read = "user-follow-read"
+    user_follow_modify = "user-follow-modify"
+    app_remote_control = "app-remote-control"
+    playlist_read_private = "playlist-read-private"
+    user_modify_playback_state = "user-modify-playback-state"
+
+    @staticmethod
+    def all() -> set['Scope']:
+        """Returns all of the authorization scopes"""
+
+        return set(scope.value for scope in Scope)
+
+    @staticmethod
+    def make_string(scopes: Iterable['Scope']) -> str:
+        """
+        Converts an iterable of scopes to a space-separated string.
+
+        * scopes: An iterable of scopes.
+
+        returns: a space-separated string of scopes
+        """
+        return " ".join([scope.value for scope in scopes])
+
+    @staticmethod
+    def from_string(scope_string: str) -> set['Scope']:
+        """
+        Converts a string of (usuallly space-separated) scopes into a
+        set of scopes
+
+        Any scope-strings that do not match any of the known scopes are
+        ignored.
+
+        * scope_string: a string of scopes
+
+        returns: a set of scopes.
+        """
+        scope_string_list = re.split(pattern=r"[^\w-]+", string=scope_string)
+        scopes = set()
+        for scope_string in sorted(scope_string_list):
+            try:
+                scope = Scope(scope_string)
+                scopes.add(scope)
+            except ValueError:
+                pass
+        return scopes

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -7,7 +7,6 @@ __all__ = ["CLIENT_CREDS_ENV_VARS", "prompt_for_user_token"]
 import logging
 import os
 import warnings
-
 import spotipy
 
 LOGGER = logging.getLogger(__name__)
@@ -117,19 +116,3 @@ def get_host_port(netloc):
         port = None
 
     return host, port
-
-
-def normalize_scope(scope):
-    if scope:
-        if isinstance(scope, str):
-            scopes = scope.split(',')
-        elif isinstance(scope, list) or isinstance(scope, tuple):
-            scopes = scope
-        else:
-            raise Exception(
-                "Unsupported scope value, please either provide a list of scopes, "
-                "or a string of scopes separated by commas"
-            )
-        return " ".join(sorted(scopes))
-    else:
-        return None

--- a/tests/integration/test_non_user_endpoints.py
+++ b/tests/integration/test_non_user_endpoints.py
@@ -364,3 +364,9 @@ class AuthTestSpotipy(unittest.TestCase):
         self.assertNotIsInstance(with_no_session._session, requests.Session)
         user = with_no_session.user(user="akx")
         self.assertEqual(user["uri"], "spotify:user:akx")
+
+    def test_available_markets(self):
+        markets = self.spotify.available_markets()["markets"]
+        self.assertTrue(isinstance(markets, list))
+        self.assertIn("US", markets)
+        self.assertIn("GB", markets)

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -209,6 +209,10 @@ class SpotipyLibraryApiTests(unittest.TestCase):
                            "http://open.spotify.com/track/3cySlItpiPiIAzU3NyHCJf"]
         cls.album_ids = ["spotify:album:6kL09DaURb7rAoqqaA51KU",
                          "spotify:album:6RTzC0rDbvagTSJLlY7AKl"]
+        cls.episode_ids = [
+            "spotify:episode:3OEdPEYB69pfXoBrhvQYeC",
+            "spotify:episode:5LEFdZ9pYh99wSz7Go2D0g"
+        ]
         cls.username = os.getenv(CCEV['client_username'])
 
         scope = (
@@ -266,6 +270,22 @@ class SpotipyLibraryApiTests(unittest.TestCase):
         self.spotify.current_user_saved_albums_delete(self.album_ids)
         resp = self.spotify.current_user_saved_albums_contains(self.album_ids)
         self.assertEqual(resp, [False, False])
+
+    def test_current_user_saved_episodes(self):
+        # Add
+        self.spotify.current_user_saved_episodes_add(self.episode_ids)
+        episodes = self.spotify.current_user_saved_episodes(market="US")
+        self.assertGreaterEqual(len(episodes['items']), 2)
+
+        # Contains
+        resp = self.spotify.current_user_saved_episodes_contains(self.episode_ids)
+        self.assertEqual(resp, [True, True])
+
+        # Remove
+        self.spotify.current_user_saved_episodes_delete(self.episode_ids)
+        resp = self.spotify.current_user_saved_episodes_contains(self.episode_ids)
+        self.assertEqual(resp, [False, False])
+
 
 
 class SpotipyUserApiTests(unittest.TestCase):

--- a/tests/integration/test_user_endpoints.py
+++ b/tests/integration/test_user_endpoints.py
@@ -287,7 +287,6 @@ class SpotipyLibraryApiTests(unittest.TestCase):
         self.assertEqual(resp, [False, False])
 
 
-
 class SpotipyUserApiTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -1,7 +1,7 @@
-import unittest
 from unittest import TestCase
 from spotipy.scope import Scope
 from spotipy.oauth2 import SpotifyAuthBase
+
 
 class SpotipyScopeTest(TestCase):
 
@@ -25,7 +25,6 @@ class SpotipyScopeTest(TestCase):
 
         converted_scopes = Scope.from_string(scope_string)
         self.assertEqual(converted_scopes, set())
-
 
     def test_scopes(self):
         scopes = {
@@ -71,8 +70,6 @@ class SpotipyScopeTest(TestCase):
         self.assertEqual(parsed_scopes, expected_scopes)
         self.assertEqual(normalized_parsed_scopes, expected_scopes)
 
-
-
     def test_invalid_types(self):
 
         numbers = [1, 2, 3]
@@ -91,4 +88,3 @@ class SpotipyScopeTest(TestCase):
         self.assertEqual(normalized_scope_string_2, "")
 
         self.assertIsNone(self.normalize_scope(None))
-

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -1,0 +1,94 @@
+import unittest
+from unittest import TestCase
+from spotipy.scope import Scope
+from spotipy.oauth2 import SpotifyAuthBase
+
+class SpotipyScopeTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.auth_manager = SpotifyAuthBase(requests_session=True)
+
+    def normalize_scope(self, scope):
+        return self.auth_manager._normalize_scope(scope)
+
+    def test_empty_scope(self):
+        scopes = set()
+        scope_string = Scope.make_string(scopes)
+
+        normalized_scope_string = self.normalize_scope(scopes)
+        normalized_scope_string_2 = self.normalize_scope(scope_string)
+
+        self.assertEqual(scope_string, "")
+        self.assertEqual(normalized_scope_string, "")
+        self.assertEqual(normalized_scope_string_2, "")
+
+        converted_scopes = Scope.from_string(scope_string)
+        self.assertEqual(converted_scopes, set())
+
+
+    def test_scopes(self):
+        scopes = {
+            Scope.playlist_modify_public,
+            Scope.playlist_read_collaborative,
+            Scope.user_read_playback_state,
+            Scope.ugc_image_upload
+        }
+        normalized_scope_string = self.normalize_scope(scopes)
+        scope_string = Scope.make_string(scopes)
+        self.assertEqual(scope_string, normalized_scope_string)
+
+        normalized_scope_string_2 = self.normalize_scope(scope_string)
+
+        converted_scopes = Scope.from_string(scope_string)
+        normalized_converted_scope = Scope.from_string(normalized_scope_string)
+        normalized_converted_scope_2 = Scope.from_string(normalized_scope_string_2)
+        self.assertEqual(scopes, converted_scopes)
+        self.assertEqual(scopes, normalized_converted_scope)
+        self.assertEqual(scopes, normalized_converted_scope_2)
+
+    def test_single_scope(self):
+        scope_string = "user-modify-playback-state"
+        scope = Scope(scope_string)
+        self.assertEqual(scope, Scope.user_modify_playback_state)
+        self.assertEqual(scope_string, scope.value)
+
+    def test_scope_string(self):
+        scope_string = (
+            "user-read-currently-playing    playlist-read-collaborative,user-library-read "
+            "playlist-read-private user-read-email"
+        )
+        expected_scopes = {
+            Scope.user_read_currently_playing,
+            Scope.playlist_read_collaborative,
+            Scope.user_library_read,
+            Scope.playlist_read_private,
+            Scope.user_read_email
+        }
+        parsed_scopes = Scope.from_string(scope_string)
+        normalized_scope_string = self.normalize_scope(scope_string)
+        normalized_parsed_scopes = Scope.from_string(normalized_scope_string)
+        self.assertEqual(parsed_scopes, expected_scopes)
+        self.assertEqual(normalized_parsed_scopes, expected_scopes)
+
+
+
+    def test_invalid_types(self):
+
+        numbers = [1, 2, 3]
+        with self.assertRaises(TypeError):
+            self.normalize_scope(numbers)
+
+        with self.assertRaises(TypeError):
+            self.normalize_scope(True)
+
+    def test_normalize_scope(self):
+
+        normalized_scope_string = self.normalize_scope([])
+        self.assertEqual(normalized_scope_string, "")
+
+        normalized_scope_string_2 = self.normalize_scope(())
+        self.assertEqual(normalized_scope_string_2, "")
+
+        self.assertIsNone(self.normalize_scope(None))
+


### PR DESCRIPTION
Added the `Scopes` enum. Made `CacheHandler` an abstract base class. Now if clients subclass this class and don't implement the required methods, they will get an error immediately upon initialization, instead of when the methods are first called. Added new endpoints.