### PR TITLE
Added MemoryCacheHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `MemoryCacheHandler`, a cache handler that simply stores the token info in memory as an instance attribute of this class.
 
+### Fixed
+
+* Fixed a bug in `CacheFileHandler.__init__`: The documentation says that the username will be retrieved from the environment, but it wasn't.
+
 ## [2.18.0] - 2021-04-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-// Add your changes here and then delete this line
+### Added
+
+* Added `MemoryCacheHandler`, a cache handler that simply stores the token info in memory as an instance attribute of this class.
 
 ## [2.18.0] - 2021-04-13
 

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -1,4 +1,4 @@
-__all__ = ['CacheHandler', 'CacheFileHandler']
+__all__ = ['CacheHandler', 'CacheFileHandler', 'MemoryCacheHandler']
 
 import errno
 import json
@@ -82,3 +82,24 @@ class CacheFileHandler(CacheHandler):
         except IOError:
             logger.warning('Couldn\'t write token to cache at: %s',
                            self.cache_path)
+
+
+class MemoryCacheHandler(CacheHandler):
+    """
+    A cache handler that simply stores the token info in memory as an
+    instance attribute of this class. The token info will be lost when this
+    instance is freed.
+    """
+
+    def __init__(self, token_info=None):
+        """
+        Parameters:
+            * token_info: The token info to store in memory. Can be None.
+        """
+        self.token_info = token_info
+
+    def get_cached_token(self):
+        return self.token_info
+
+    def save_token_to_cache(self, token_info):
+        self.token_info = token_info

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -3,6 +3,8 @@ __all__ = ['CacheHandler', 'CacheFileHandler', 'MemoryCacheHandler']
 import errno
 import json
 import logging
+import os
+from spotipy.util import CLIENT_CREDS_ENV_VARS
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,7 @@ class CacheFileHandler(CacheHandler):
             self.cache_path = cache_path
         else:
             cache_path = ".cache"
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             if username:
                 cache_path += "-" + str(username)
             self.cache_path = cache_path

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -6,7 +6,7 @@ import unittest
 import six.moves.urllib.parse as urllibparse
 
 from spotipy import SpotifyOAuth, SpotifyImplicitGrant, SpotifyPKCE
-from spotipy.cache_handler import CacheHandler
+from spotipy.cache_handler import MemoryCacheHandler
 from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOauthError
 from spotipy.oauth2 import SpotifyStateError
 
@@ -49,18 +49,6 @@ def _make_implicitgrantauth(*args, **kwargs):
 
 def _make_pkceauth(*args, **kwargs):
     return SpotifyPKCE("CLID", "REDIR", "STATE", *args, **kwargs)
-
-
-class MemoryCache(CacheHandler):
-    def __init__(self, token_info=None):
-        self.token_info = token_info
-
-    def get_cached_token(self):
-        return self.token_info
-
-    def save_token_to_cache(self, token_info):
-        self.token_info = token_info
-        return None
 
 
 class OAuthCacheTest(unittest.TestCase):
@@ -161,7 +149,7 @@ class OAuthCacheTest(unittest.TestCase):
         scope = "playlist-modify-private"
         tok = _make_fake_token(1, 1, scope)
 
-        spot = _make_oauth(scope, cache_handler=MemoryCache())
+        spot = _make_oauth(scope, cache_handler=MemoryCacheHandler())
         spot.cache_handler.save_token_to_cache(tok)
         cached_tok = spot.cache_handler.get_cached_token()
 


### PR DESCRIPTION
`MemoryCacheHandler` is useful for scripts that don't need to save the token info to persistent storage. Please merge this into v3 because I'm working on some changes on that branch that rely on this change.