### PR TITLE
Spurious warning message in auth manager initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed a bug in `CacheFileHandler.__init__`: The documentation says that the username will be retrieved from the environment, but it wasn't.
+* Fixed a bug in the initializers for the auth managers that produced a spurious warning message if you provide a cache handler and you set a value for the "SPOTIPY_CLIENT_USERNAME" environment variable.
 
 ## [2.18.0] - 2021-04-13
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -315,7 +315,6 @@ class SpotifyOAuth(SpotifyAuthBase):
         self.redirect_uri = redirect_uri
         self.state = state
         self.scope = self._normalize_scope(scope)
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to SpotifyOAuth " +
                           "will be deprecated. Instead, please create a CacheFileHandler " +
@@ -338,7 +337,7 @@ class SpotifyOAuth(SpotifyAuthBase):
                 + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
-
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path
@@ -673,7 +672,6 @@ class SpotifyPKCE(SpotifyAuthBase):
         self.redirect_uri = redirect_uri
         self.state = state
         self.scope = self._normalize_scope(scope)
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to SpotifyPKCE " +
                           "will be deprecated. Instead, please create a CacheFileHandler " +
@@ -694,6 +692,7 @@ class SpotifyPKCE(SpotifyAuthBase):
                 "type(cache_handler): " + str(type(cache_handler)) + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path
@@ -1071,7 +1070,6 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         self.client_id = client_id
         self.redirect_uri = redirect_uri
         self.state = state
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to " +
                           "SpotifyImplicitGrant will be deprecated. Instead, please create " +
@@ -1093,6 +1091,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
                 "type(cache_handler): " + str(type(cache_handler)) + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path


### PR DESCRIPTION
If you have your username stored in the "SPOTIPY_CLIENT_USERNAME" environment variable and you create an auth manager and assign a cache handler to it like so (like you should):
```python
auth_manager=SpotifyOAuth(
    scope=scope,
    cache_handler=CacheFileHandler()
)
```
Then you will get the following error message:
> spotipy testing/spotipy/oauth2.py:333: UserWarning: A cache_handler has been specified along with a cache_path or username. The cache_path and username arguments will be ignored.
  warnings.warn("A cache_handler has been specified along with a cache_path or " +

This error message should only appear if you pass the username *directly* to the initializer, not if you happen to have it stored in an environment variable.