### PR TITLE
Set cache checking to false so that failing test passes

### DIFF
--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -245,7 +245,7 @@ class TestSpotifyClientCredentials(unittest.TestCase):
     def test_spotify_client_credentials_get_access_token(self):
         oauth = SpotifyClientCredentials(client_id='ID', client_secret='SECRET')
         with self.assertRaises(SpotifyOauthError) as error:
-            oauth.get_access_token()
+            oauth.get_access_token(check_cache=False)
         self.assertEqual(error.exception.error, 'invalid_client')
 
 


### PR DESCRIPTION
The `SpotifyOauthError` wasn't being raised when I ran the test. I found out that it was happening because it was using a cached valid token, intead of the authentication that was supposed to fail. Removed cache checking in the test.