### PR TITLE
Fallback on decoding error responses into string if decoding into JSON fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixed a bug in `CacheFileHandler.__init__`: The documentation says that the username will be retrieved from the environment, but it wasn't.
+* Fixed a bug in the initializers for the auth managers that produced a spurious warning message if you provide a cache handler and you set a value for the "SPOTIPY_CLIENT_USERNAME" environment variable.
 
 ## [2.18.0] - 2021-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added `MemoryCacheHandler`, a cache handler that simply stores the token info in memory as an instance attribute of this class.
+* If a network request returns an error status code but the response body cannot be decoded into JSON, then fall back on decoding the body into a string.
 
 ### Fixed
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -245,6 +245,7 @@ class Spotify(object):
             response.raise_for_status()
             results = response.json()
         except requests.exceptions.HTTPError as http_error:
+            response = http_error.response
             try:
                 json_response = response.json()
                 error = json_response.get("error", {})
@@ -260,7 +261,7 @@ class Spotify(object):
 
             logger.error(
                 'HTTP Error for %s to %s with Params: %s returned %s due to %s',
-                 method, url, args.get("params"), response.status_code, msg
+                method, url, args.get("params"), response.status_code, msg
             )
 
             raise SpotifyException(

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -253,7 +253,9 @@ class Spotify(object):
             except ValueError:
                 # if the response cannnot be decoded into JSON (which raises a ValueError),
                 # then try to decode it into text
-                msg = response.text
+
+                # if we receive an empty string (which is falsy), then replace it with `None`
+                msg = response.text or None
                 reason = None
 
             logger.error(

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -439,13 +439,12 @@ class SpotifyOAuth(SpotifyAuthBase):
         self._open_auth_url()
         server.handle_request()
 
-        if self.state is not None and server.state != self.state:
-            raise SpotifyStateError(self.state, server.state)
-
-        if server.auth_code is not None:
-            return server.auth_code
-        elif server.error is not None:
+        if server.error is not None:
             raise server.error
+        elif self.state is not None and server.state != self.state:
+            raise SpotifyStateError(self.state, server.state)
+        elif server.auth_code is not None:
+            return server.auth_code
         else:
             raise SpotifyOauthError("Server listening on localhost has not been accessed")
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -315,7 +315,6 @@ class SpotifyOAuth(SpotifyAuthBase):
         self.redirect_uri = redirect_uri
         self.state = state
         self.scope = self._normalize_scope(scope)
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to SpotifyOAuth " +
                           "will be deprecated. Instead, please create a CacheFileHandler " +
@@ -338,7 +337,7 @@ class SpotifyOAuth(SpotifyAuthBase):
                 + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
-
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path
@@ -673,7 +672,6 @@ class SpotifyPKCE(SpotifyAuthBase):
         self.redirect_uri = redirect_uri
         self.state = state
         self.scope = self._normalize_scope(scope)
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to SpotifyPKCE " +
                           "will be deprecated. Instead, please create a CacheFileHandler " +
@@ -694,6 +692,7 @@ class SpotifyPKCE(SpotifyAuthBase):
                 "type(cache_handler): " + str(type(cache_handler)) + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path
@@ -1071,7 +1070,6 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
         self.client_id = client_id
         self.redirect_uri = redirect_uri
         self.state = state
-        username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
         if username or cache_path:
             warnings.warn("Specifying cache_path or username as arguments to " +
                           "SpotifyImplicitGrant will be deprecated. Instead, please create " +
@@ -1093,6 +1091,7 @@ class SpotifyImplicitGrant(SpotifyAuthBase):
                 "type(cache_handler): " + str(type(cache_handler)) + " != " + str(CacheHandler)
             self.cache_handler = cache_handler
         else:
+            username = (username or os.getenv(CLIENT_CREDS_ENV_VARS["client_username"]))
             self.cache_handler = CacheFileHandler(
                 username=username,
                 cache_path=cache_path


### PR DESCRIPTION
In their ultimate wisdom, Spotify decided to return a plain string for some error responses instead of returning one of their documented JSON error objects.

This addresses #688. Instead of
```
spotipy.exceptions.SpotifyException: http status: 403, code:-1 - https://api.spotify.com/v1/me/:
 error, reason: None
```
you get
```
spotipy.exceptions.SpotifyException: http status: 403, code:-1 - https://api.spotify.com/v1/me/player/pause:
 User not approved for app, reason: None
```