### PR TITLE
update current_user_saved_albums function message

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1182,7 +1182,7 @@ class Spotify(object):
             "Your Music" library
 
             Parameters:
-                - limit - the number of albums to return
+                - limit - the number of albums to return (MAX_LIMIT=50)
                 - offset - the index of the first album to return
                 - market - an ISO 3166-1 alpha-2 country code.
 


### PR DESCRIPTION
Max limit Spotipy can handler without getting this error:
"""
spotipy.exceptions.SpotifyException: 
http status: 400, code:-1 - https://api.spotify.com/v1/me/tracks?limit=51&offset=0: **Invalid limit**, reason: None
"""