### PR TITLE
Update link to usage scopes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,7 +143,7 @@ Scopes
 ------
 
 See `Using
-Scopes <https://developer.spotify.com/web-api/using-scopes/>`_ for information
+Scopes <https://developer.spotify.com/documentation/general/guides/authorization/scopes/>`_ for information
 about scopes.
 
 Redirect URI


### PR DESCRIPTION
I noticed that the usage scopes link leads to a 404. I updated that link with the current location