### PR TITLE
Remove query parameters from URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Added `RedisCacheHandler`, a cache handler that stores the token info in Redis.
+* Changed URI handling in `client.Spotify._get_id()` to remove qureies if provided by error.
 
 ## [2.19.0] - 2021-08-12
 

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -12,8 +12,6 @@ import requests
 import six
 import urllib3
 
-import re
-
 from spotipy.exceptions import SpotifyException
 
 logger = logging.getLogger(__name__)

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -12,6 +12,8 @@ import requests
 import six
 import urllib3
 
+import re
+
 from spotipy.exceptions import SpotifyException
 
 logger = logging.getLogger(__name__)
@@ -1913,7 +1915,7 @@ class Spotify(object):
             if type != fields[-2]:
                 logger.warning('Expected id of type %s but found type %s %s',
                                type, fields[-2], id)
-            return fields[-1]
+            return fields[-1].spliy("?")[0]
         fields = id.split("/")
         if len(fields) >= 3:
             itype = fields[-2]

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -1915,7 +1915,7 @@ class Spotify(object):
             if type != fields[-2]:
                 logger.warning('Expected id of type %s but found type %s %s',
                                type, fields[-2], id)
-            return fields[-1].spliy("?")[0]
+            return fields[-1].split("?")[0]
         fields = id.split("/")
         if len(fields) >= 3:
             itype = fields[-2]


### PR DESCRIPTION
#757

This PR adds a split to the _get_id function to make sure an URI provided by the user removes any element following an interrogation mark to only return the id element of the URI.