### PR TITLE
Allow to set custom key in RedisCacheHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `RedisCacheHandler`, a cache handler that stores the token info in Redis.
 * Changed URI handling in `client.Spotify._get_id()` to remove qureies if provided by error.
+* Added a new parameter to `RedisCacheHandler` to allow custom keys (instead of the default `token_info` key)
 
 ## [2.19.0] - 2021-08-12
 

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -152,18 +152,21 @@ class RedisCacheHandler(CacheHandler):
     A cache handler that stores the token info in the Redis.
     """
 
-    def __init__(self, redis):
+    def __init__(self, redis, key=None):
         """
         Parameters:
             * redis: Redis object provided by redis-py library
             (https://github.com/redis/redis-py)
+            * key: May be supplied, will otherwise be generated
+                   (takes precedence over `token_info`)
         """
         self.redis = redis
+        self.key = key if key else 'token_info'
 
     def get_cached_token(self):
         token_info = None
         try:
-            token_info = json.loads(self.redis.get('token_info'))
+            token_info = json.loads(self.redis.get(self.key))
         except RedisError as e:
             logger.warning('Error getting token from cache: ' + str(e))
 
@@ -171,6 +174,6 @@ class RedisCacheHandler(CacheHandler):
 
     def save_token_to_cache(self, token_info):
         try:
-            self.redis.set('token_info', json.dumps(token_info))
+            self.redis.set(self.key, json.dumps(token_info))
         except RedisError as e:
             logger.warning('Error saving token to cache: ' + str(e))

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -166,7 +166,8 @@ class RedisCacheHandler(CacheHandler):
     def get_cached_token(self):
         token_info = None
         try:
-            token_info = json.loads(self.redis.get(self.key))
+            if self.redis.exists(self.key):
+                token_info = json.loads(self.redis.get(self.key))
         except RedisError as e:
             logger.warning('Error getting token from cache: ' + str(e))
 


### PR DESCRIPTION
I would like to use a different key than the one that is always set, so I thought it might be a good idea to allow users of the `RedisCacheHandler` to supply their own key and only set it to the default value of `token_info` if the key is not supplied as an argument.