### PR TITLE
Simplify check for existing token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `RedisCacheHandler`, a cache handler that stores the token info in Redis.
 * Changed URI handling in `client.Spotify._get_id()` to remove qureies if provided by error.
 * Added a new parameter to `RedisCacheHandler` to allow custom keys (instead of the default `token_info` key)
+* Simplify check for existing token in `RedisCacheHandler`
 
 ## [2.19.0] - 2021-08-12
 

--- a/spotipy/cache_handler.py
+++ b/spotipy/cache_handler.py
@@ -166,8 +166,9 @@ class RedisCacheHandler(CacheHandler):
     def get_cached_token(self):
         token_info = None
         try:
-            if self.redis.exists(self.key):
-                token_info = json.loads(self.redis.get(self.key))
+            token_info = self.redis.get(self.key)
+            if token_info:
+                return json.loads(token_info)
         except RedisError as e:
             logger.warning('Error getting token from cache: ' + str(e))
 


### PR DESCRIPTION
Follow-up of #761 which simplifies the check for an existing token in a Redis database based on https://github.com/plamere/spotipy/pull/761#issuecomment-999652928