### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setup(
     author="@plamere",
     author_email="paul@echonest.com",
     url='https://spotipy.readthedocs.org/',
+    project_urls={
+        'Source': 'https://github.com/plamere/spotipy',
+    },
     install_requires=[
         'redis>=3.5.3',
         'requests>=2.25.0',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)