### PR TITLE
Fix text attribute for Response object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed URI handling in `client.Spotify._get_id()` to remove qureies if provided by error.
 * Added a new parameter to `RedisCacheHandler` to allow custom keys (instead of the default `token_info` key)
 * Simplify check for existing token in `RedisCacheHandler`
+* Fix `AttributeError` for `text` attribute of the `Response` object
 
 ## [2.19.0] - 2021-08-12
 

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -140,7 +140,7 @@ class SpotifyAuthBase(object):
             # then try do decode it into text
 
             # if we receive an empty string (which is falsy), then replace it with `None`
-            error = response.txt or None
+            error = response.text or None
             error_description = None
 
         raise SpotifyOauthError(


### PR DESCRIPTION
I got 
```
'Response' object has no attribute 'txt'
```
for a request and realized the correct attribute is [`text`](https://docs.python-requests.org/en/latest/api/#requests.Response.text) not `txt` for the `Response` object.