### PR TITLE
Added specifications for windows users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,17 @@ If you would like to contribute to spotipy follow these steps:
 ### Export the needed environment variables
 
 ```bash
+# Linux or Mac
 export SPOTIPY_CLIENT_ID=client_id_here
 export SPOTIPY_CLIENT_SECRET=client_secret_here
 export SPOTIPY_CLIENT_USERNAME=client_username_here # This is actually an id not spotify display name
 export SPOTIPY_REDIRECT_URI=http://localhost:8080 # Make url is set in app you created to get your ID and SECRET
+
+# Windows
+$env:SPOTIPY_CLIENT_ID="client_id_here"
+$env:SPOTIPY_CLIENT_SECRET="client_secret_here"
+$env:SPOTIPY_CLIENT_USERNAME="client_username_here" 
+$env:SPOTIPY_REDIRECT_URI="http://localhost:8080" 
 ```
 
 ### Create virtual environment, install dependencies, run tests:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -132,7 +132,7 @@ class SpotifyOAuth that can be used to authenticate requests like so::
         print(idx, track['artists'][0]['name'], " – ", track['name'])
 
 or if you are reluctant to immortalize your app credentials in your source code,
-you can set environment variables like so (use ``SET`` instead of ``export``
+you can set environment variables like so (use ``$env:"credentials"`` instead of ``export``
 on Windows)::
 
     export SPOTIPY_CLIENT_ID='your-spotify-client-id'


### PR DESCRIPTION
I added a specification for Windows users attempting to set their environment variables. 
($ indicates a variable), (env:) indicates an environment variable.
The full syntax is $env:var_name = "my_env_var" 
set was failing for me as it was not persisting even for a single session.