### PR TITLE
Fixes "Only valid bearer authentication supported, reason: None"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated the documentation to specify ISO-639-1 language codes.
 * Fix `AttributeError` for `text` attribute of the `Response` object
 * Require redis v3 if python2.7 (fixes readthedocs)
+* For backward-compatibility, ensure `get_access_token()` returns a token instead of dict by default,
+  fixes https://github.com/plamere/spotipy/issues/687 and https://github.com/plamere/spotipy/issues/828
 
 ## [2.20.0] - 2022-06-18
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -55,7 +55,7 @@ def index():
 
     if request.args.get("code"):
         # Step 3. Being redirected from Spotify auth page
-        auth_manager.get_access_token(request.args.get("code"))
+        auth_manager.get_access_token(request.args.get("code"), as_dict=True)
         return redirect('/')
 
     if not auth_manager.validate_token(cache_handler.get_cached_token()):

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -209,9 +209,9 @@ class Spotify(object):
         if not self.auth_manager:
             return {}
         try:
-            token = self.auth_manager.get_access_token(as_dict=False)
-        except TypeError:
             token = self.auth_manager.get_access_token()
+        except TypeError:
+            token = self.auth_manager.get_access_token(as_dict=True)
         return {"Authorization": "Bearer {0}".format(token)}
 
     def _internal_call(self, method, url, payload, params):

--- a/spotipy/oauth2.py
+++ b/spotipy/oauth2.py
@@ -210,7 +210,7 @@ class SpotifyClientCredentials(SpotifyAuthBase):
         else:
             self.cache_handler = CacheFileHandler()
 
-    def get_access_token(self, as_dict=True, check_cache=True):
+    def get_access_token(self, as_dict=False, check_cache=True):
         """
         If a valid access token is in memory, returns it
         Else feches a new token and returns it
@@ -503,7 +503,7 @@ class SpotifyOAuth(SpotifyAuthBase):
             return self.parse_response_code(response)
         return self.get_auth_response()
 
-    def get_access_token(self, code=None, as_dict=True, check_cache=True):
+    def get_access_token(self, code=None, as_dict=False, check_cache=True):
         """ Gets the access token for the app given the code
 
             Parameters:

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -97,7 +97,7 @@ def prompt_for_user_token(
 
     if not token_info:
         code = sp_oauth.get_auth_response()
-        token = sp_oauth.get_access_token(code, as_dict=False)
+        token = sp_oauth.get_access_token(code)
     else:
         return token_info["access_token"]
 

--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -245,7 +245,7 @@ class TestSpotifyClientCredentials(unittest.TestCase):
     def test_spotify_client_credentials_get_access_token(self):
         oauth = SpotifyClientCredentials(client_id='ID', client_secret='SECRET')
         with self.assertRaises(SpotifyOauthError) as error:
-            oauth.get_access_token(check_cache=False)
+            oauth.get_access_token(as_dict=True, check_cache=False)
         self.assertEqual(error.exception.error, 'invalid_client')
 
 


### PR DESCRIPTION
Fixes https://github.com/plamere/spotipy/issues/687, https://github.com/plamere/spotipy/issues/828

------------

To keep backward-incompatibility we shouldn't have made `as_dict=True` the default in `get_access_token` methods. This PR swaps it back to `False`. Therefore this must be seen as a bugfix rather than a new backward-incompatible change.

Normally, this shouldn't have too much effect on new code as we now don't recommend to get the token independently via `get_access_token()` in order to authenticate (see README).

If you have been using `get_access_token()` in new code, you should now use `get_access_token(as_dict=True)`.