### PR TITLE
Add missing activation of virtualenv command to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ $env:SPOTIPY_REDIRECT_URI="http://localhost:8080"
 
 ```bash
 $ virtualenv --python=python3.7 env
+$ source env/bin/activate
 (env) $ pip install --user -e .
 (env) $ python -m unittest discover -v tests
 ```


### PR DESCRIPTION
I was following the instructions in `CONTRIBUTING.md` and I noticed that the command to activate the virtualenv was missing