### PR TITLE
Warning on Spotify URI RegEx fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Add your changes below.
 
 ### Added
 
+- Added a warning if the URI regex did not match the input.
+
 ### Fixed
 
 ### Removed

--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -2140,6 +2140,7 @@ class Spotify:
 
     def _get_uri(self, type, id):
         if self._is_uri(id):
+            warnings.warn(f"{repr(id)} did not match the Spotify URI RegEx.", UserWarning)
             return id
         else:
             return "spotify:" + type + ":" + self._get_id(type, id)


### PR DESCRIPTION
Closes #1221

While implementing, I noticed that such a warning would probably be more disruptive than helpful.
Currently there are multiple methods that *should* accept both tracks and episodes, but the regex only checks for tracks.

Any thoughts?