### PR TITLE
Reduce `artist_album` limit

### DIFF
--- a/spotipy/client.py
+++ b/spotipy/client.py
@@ -400,7 +400,7 @@ class Spotify:
         return self._get("artists/?ids=" + ",".join(tlist))
 
     def artist_albums(
-        self, artist_id, album_type=None, include_groups=None, country=None, limit=20, offset=0
+        self, artist_id, album_type=None, include_groups=None, country=None, limit=10, offset=0
     ):
         """ Get Spotify catalog information about an artist's albums
 


### PR DESCRIPTION
Reduces the limit so that a query called without explicit limit is valid with the new changes to the spotify API.

Fixes #1231